### PR TITLE
Agent-assisted release automations

### DIFF
--- a/.claude/commands/prerelease.md
+++ b/.claude/commands/prerelease.md
@@ -1,0 +1,18 @@
+1. Verify you're on the main branch and it's up to date with origin
+2. Parse the current version from `packages/dependicus/package.json`
+3. Validate the version is in format `X.Y.Z-rc.N` (e.g., `0.1.9-rc.5`)
+    - If not in this format, ERROR and tell the user to manually fix it first
+4. Increment the rc number: `-rc.5` → `-rc.6`
+5. Update the version in `packages/dependicus/package.json`
+6. Commit the change:
+    ```bash
+    git add packages/dependicus/package.json
+    git commit -m "Prerelease v<new-version>"
+    ```
+7. **STOP and ask the user to run `mise prerelease`**. Wait for them to confirm that the publish succeeded before continuing.
+8. After the user confirms, create and push the tag:
+    ```bash
+    git tag v<new-version>
+    git push origin main
+    git push origin v<new-version>
+    ```

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -1,0 +1,26 @@
+1. Verify you're on the main branch and it's up to date with origin
+2. Parse the current version from `packages/dependicus/package.json`
+3. Strip the `-rc.N` suffix to get the stable version (e.g., `0.1.9-rc.5` → `0.1.9`)
+    - If the version is already stable (no `-rc.N`), ERROR and tell the user
+4. Update the version in `packages/dependicus/package.json`
+5. Update CHANGELOG.md: replace "Unreleased" with today's date, remove empty sections
+6. Commit the version and changelog changes:
+    ```bash
+    git add packages/dependicus/package.json CHANGELOG.md
+    git commit -m "Release v<version>"
+    ```
+7. **STOP and ask the user to run `mise release`**. Wait for them to confirm that the publish succeeded before continuing.
+8. After the user confirms:
+    - Create and push the tag:
+        ```bash
+        git tag v<version>
+        git push origin main
+        git push origin v<version>
+        ```
+    - Copy the release notes for this version from CHANGELOG.md to the clipboard using `pbcopy`
+9. Final commit: bump to the next patch version with `-rc.0` suffix (e.g., `0.1.9` → `0.1.10-rc.0`), add a new unreleased section to CHANGELOG.md, commit and push:
+    ```bash
+    git add packages/dependicus/package.json CHANGELOG.md
+    git commit -m "Begin v<next-version> development"
+    git push origin main
+    ```

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,15 @@
+# Changelog
+
+<!-- loosely based on https://keepachangelog.com/en/1.0.0/ -->
+
+## 0.1.9 - Unreleased
+
+First usable public release.
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -5,3 +5,7 @@ Never invoke npx. Instead, use pnpm exec or bun, depending on which package mana
 When opening issues or making PRs, make at least one joke about ducks, geese, or waterfowl in general.
 
 Read @mise.toml and prefer Mise tasks over random shell expressions.
+
+## Changelog
+
+When updating CHANGELOG.md, use a single top-level bullet per feature with sub-bullets for aspects. Focus on the final feature, not the sequence of events leading to it. Only document user-facing changes.


### PR DESCRIPTION
These simple Claude Code commands do the drudgery of bumping versions, reordering the changelog, and making tags.