### PR TITLE
Fix bad instructions in GitHub issues; remove unnecessary fallbacks

### DIFF
--- a/packages/dependicus/src/cli.test.ts
+++ b/packages/dependicus/src/cli.test.ts
@@ -260,8 +260,8 @@ describe('dependicusCli', () => {
                 {
                     linearApiKey: 'test-key',
                     dryRun: undefined,
-                    dependicusBaseUrl: 'https://example.com',
                     getDetailUrl: expect.any(Function),
+                    providerInfoMap: expect.any(Map),
                     cooldownDays: 7,
                     allowNewIssues: true,
                 },

--- a/packages/dependicus/src/cli.ts
+++ b/packages/dependicus/src/cli.ts
@@ -10,6 +10,7 @@ import {
     readDependicusJson,
     mergeProviderDependencies,
     createDetailUrlBuilder,
+    buildProviderInfoMap,
     CacheService,
 } from '@dependicus/core';
 import type { FactStore, ProviderOutput, DependencyProvider } from '@dependicus/core';
@@ -346,6 +347,7 @@ export function dependicusCli(config: DependicusCliConfig): {
                             effectiveConfig.dependicusBaseUrl,
                             providers,
                         );
+                        const providerInfoMap = buildProviderInfoMap(providers);
 
                         await reconcileIssues(
                             deps,
@@ -353,8 +355,8 @@ export function dependicusCli(config: DependicusCliConfig): {
                             {
                                 linearApiKey,
                                 dryRun: options.dryRun,
-                                dependicusBaseUrl: effectiveConfig.dependicusBaseUrl,
                                 getDetailUrl,
+                                providerInfoMap,
                                 cooldownDays:
                                     options.cooldownDays != null
                                         ? Number(options.cooldownDays)
@@ -447,6 +449,7 @@ export function dependicusCli(config: DependicusCliConfig): {
                             effectiveConfig.dependicusBaseUrl,
                             providers,
                         );
+                        const providerInfoMap = buildProviderInfoMap(providers);
 
                         await reconcileGitHubIssues(
                             deps,
@@ -454,8 +457,8 @@ export function dependicusCli(config: DependicusCliConfig): {
                             {
                                 githubToken,
                                 dryRun: options.dryRun,
-                                dependicusBaseUrl: effectiveConfig.dependicusBaseUrl,
                                 getDetailUrl,
+                                providerInfoMap,
                                 cooldownDays:
                                     options.cooldownDays != null
                                         ? Number(options.cooldownDays)

--- a/packages/github-issues/src/issueDescriptions.ts
+++ b/packages/github-issues/src/issueDescriptions.ts
@@ -41,7 +41,7 @@ export function buildIssueDescription(
     minVersion: string,
     effectiveLatestVersion: string,
     getDetailUrl: DetailUrlFn,
-    providerInfo?: ProviderInfo,
+    providerInfo: ProviderInfo,
     dueDate?: string,
 ): string {
     const { name, ecosystem, versions, worstCompliance } = dep;
@@ -99,15 +99,13 @@ export function buildIssueDescription(
         };
     });
 
-    const installCommand = providerInfo?.installCommand ?? 'install';
-    const supportsCatalog = providerInfo?.supportsCatalog ?? false;
-    const catalogFile = providerInfo?.catalogFile;
+    const { installCommand, supportsCatalog, catalogFile } = providerInfo;
     const patchHint =
-        providerInfo?.patchHint ??
+        providerInfo.patchHint ??
         'This dependency has local patches applied. When upgrading, check if the patches are still needed or should be removed.';
-    const updatePrefix = providerInfo?.updatePrefix ?? 'Update the version in:';
+    const updatePrefix = providerInfo.updatePrefix ?? 'Update the version in:';
     const updateSuffix =
-        providerInfo?.updateSuffix ?? `Then, run \`${installCommand}\` to update the lockfile.`;
+        providerInfo.updateSuffix ?? `Then, run \`${installCommand}\` to update the lockfile.`;
     const urlPatterns = store.getDependencyFact<Record<string, string>>(name, FactKeys.URLS) ?? {};
     const urls = resolveUrlPatterns(urlPatterns, { name, version: version.version });
 
@@ -172,7 +170,7 @@ export function buildGroupIssueDescription(
     group: OutdatedGroup,
     store: FactStore,
     getDetailUrl: DetailUrlFn,
-    providerInfoMap?: Map<string, ProviderInfo>,
+    providerInfoMap: Map<string, ProviderInfo>,
     dueDate?: string,
 ): string {
     const { groupName, dependencies, worstCompliance } = group;
@@ -180,12 +178,18 @@ export function buildGroupIssueDescription(
     const notificationsOnly = group.policy.type === 'fyi';
 
     const firstDep = dependencies[0];
-    const groupProviderInfo = firstDep ? providerInfoMap?.get(firstDep.ecosystem) : undefined;
-    const installCommand = groupProviderInfo?.installCommand ?? 'install';
-    const supportsCatalog = groupProviderInfo?.supportsCatalog ?? false;
-    const catalogFile = groupProviderInfo?.catalogFile;
+    if (!firstDep) {
+        throw new Error(`Group "${groupName}" has no dependencies`);
+    }
+    const groupProviderInfo = providerInfoMap.get(firstDep.ecosystem);
+    if (!groupProviderInfo) {
+        throw new Error(
+            `No provider info for ecosystem "${firstDep.ecosystem}" in group "${groupName}"`,
+        );
+    }
+    const { installCommand, supportsCatalog, catalogFile } = groupProviderInfo;
     const updateInstructions =
-        groupProviderInfo?.updateInstructions ??
+        groupProviderInfo.updateInstructions ??
         `Update each dependency's version in the appropriate config file, then run \`${installCommand}\`.`;
 
     const context = {

--- a/packages/github-issues/src/issueReconciler.test.ts
+++ b/packages/github-issues/src/issueReconciler.test.ts
@@ -66,7 +66,19 @@ function makeStore(dependencyName: string = 'test-pkg', version: string = '1.0.0
 const baseConfig: IssueReconcilerConfig = {
     githubToken: 'test-token',
     dryRun: false,
-    dependicusBaseUrl: 'https://example.com/dependicus',
+    getDetailUrl: (_eco, pkg, ver) => `https://example.com/details/${pkg}@${ver}.html`,
+    providerInfoMap: new Map([
+        [
+            'npm',
+            {
+                name: 'pnpm',
+                ecosystem: 'npm',
+                supportsCatalog: false,
+                installCommand: 'pnpm install',
+                urlPatterns: { Registry: 'https://www.npmjs.com/package/{{name}}' },
+            },
+        ],
+    ]),
 };
 
 function makeSpec(overrides: Partial<GitHubIssueSpec> = {}): GitHubIssueSpec {

--- a/packages/github-issues/src/issueReconciler.ts
+++ b/packages/github-issues/src/issueReconciler.ts
@@ -19,7 +19,6 @@ import {
     isWithinCooldown,
     isWithinNotificationRateLimit,
     hasMajorVersionSinceLastUpdate,
-    getDetailFilename,
 } from '@dependicus/core';
 import { GitHubIssueService, DependicusIssue } from './GitHubIssueService';
 import type {
@@ -39,16 +38,14 @@ import {
 export interface IssueReconcilerConfig {
     githubToken: string;
     dryRun?: boolean;
-    /** Base URL for Dependicus HTML pages (for links in issue descriptions) */
-    dependicusBaseUrl: string;
     /** Builds the full detail page URL for a given package version. */
-    getDetailUrl?: DetailUrlFn;
+    getDetailUrl: DetailUrlFn;
     /** Cooldown days before creating issues for newly-published versions */
     cooldownDays?: number;
     /** Whether to restrict new issue creation (e.g., only on main branch) */
     allowNewIssues?: boolean;
     /** Provider info map (ecosystem -> ProviderInfo) for presentation metadata */
-    providerInfoMap?: Map<string, ProviderInfo>;
+    providerInfoMap: Map<string, ProviderInfo>;
     /** Default rate limit days for notification throttling. Used when per-policy rateLimitDays is not set. */
     rateLimitDays?: number;
 }
@@ -232,13 +229,7 @@ export async function reconcileGitHubIssues(
     const dryRun = config.dryRun ?? false;
     const allowNewIssues = config.allowNewIssues ?? true;
     const configRateLimitDays = config.rateLimitDays;
-    const dependicusBaseUrl = config.dependicusBaseUrl;
-    const getDetailUrl: DetailUrlFn =
-        config.getDetailUrl ??
-        ((_eco, pkg, ver) => {
-            const filename = getDetailFilename(pkg, ver);
-            return `${dependicusBaseUrl}/details/${filename}`;
-        });
+    const getDetailUrl = config.getDetailUrl;
 
     const githubService = new GitHubIssueService(config.githubToken, { dryRun });
 
@@ -521,7 +512,10 @@ export async function reconcileGitHubIssues(
         if (dueDateStr && !notificationsOnly) {
             title = `${title} (due ${dueDateStr})`;
         }
-        const providerInfo = config.providerInfoMap?.get(dep.ecosystem);
+        const providerInfo = config.providerInfoMap.get(dep.ecosystem);
+        if (!providerInfo) {
+            throw new Error(`No provider info for ecosystem "${dep.ecosystem}"`);
+        }
         const description = buildIssueDescription(
             dep,
             scopedStore,

--- a/packages/linear/src/issueDescriptions.ts
+++ b/packages/linear/src/issueDescriptions.ts
@@ -41,7 +41,7 @@ export function buildIssueDescription(
     minVersion: string,
     effectiveLatestVersion: string,
     getDetailUrl: DetailUrlFn,
-    providerInfo?: ProviderInfo,
+    providerInfo: ProviderInfo,
 ): string {
     const { name, ecosystem, versions, worstCompliance } = dep;
     const version = versions[0];
@@ -98,15 +98,13 @@ export function buildIssueDescription(
         };
     });
 
-    const installCommand = providerInfo?.installCommand ?? 'install';
-    const supportsCatalog = providerInfo?.supportsCatalog ?? false;
-    const catalogFile = providerInfo?.catalogFile;
+    const { installCommand, supportsCatalog, catalogFile } = providerInfo;
     const patchHint =
-        providerInfo?.patchHint ??
+        providerInfo.patchHint ??
         'This dependency has local patches applied. When upgrading, check if the patches are still needed or should be removed.';
-    const updatePrefix = providerInfo?.updatePrefix ?? 'Update the version in:';
+    const updatePrefix = providerInfo.updatePrefix ?? 'Update the version in:';
     const updateSuffix =
-        providerInfo?.updateSuffix ?? `Then, run \`${installCommand}\` to update the lockfile.`;
+        providerInfo.updateSuffix ?? `Then, run \`${installCommand}\` to update the lockfile.`;
     const urlPatterns = store.getDependencyFact<Record<string, string>>(name, FactKeys.URLS) ?? {};
     const urls = resolveUrlPatterns(urlPatterns, { name, version: version.version });
 
@@ -170,19 +168,25 @@ export function buildGroupIssueDescription(
     group: OutdatedGroup,
     store: FactStore,
     getDetailUrl: DetailUrlFn,
-    providerInfoMap?: Map<string, ProviderInfo>,
+    providerInfoMap: Map<string, ProviderInfo>,
 ): string {
     const { groupName, dependencies, worstCompliance } = group;
 
     const notificationsOnly = group.policy.type === 'fyi';
 
     const firstDep = dependencies[0];
-    const groupProviderInfo = firstDep ? providerInfoMap?.get(firstDep.ecosystem) : undefined;
-    const installCommand = groupProviderInfo?.installCommand ?? 'install';
-    const supportsCatalog = groupProviderInfo?.supportsCatalog ?? false;
-    const catalogFile = groupProviderInfo?.catalogFile;
+    if (!firstDep) {
+        throw new Error(`Group "${groupName}" has no dependencies`);
+    }
+    const groupProviderInfo = providerInfoMap.get(firstDep.ecosystem);
+    if (!groupProviderInfo) {
+        throw new Error(
+            `No provider info for ecosystem "${firstDep.ecosystem}" in group "${groupName}"`,
+        );
+    }
+    const { installCommand, supportsCatalog, catalogFile } = groupProviderInfo;
     const updateInstructions =
-        groupProviderInfo?.updateInstructions ??
+        groupProviderInfo.updateInstructions ??
         `Update each dependency's version in the appropriate config file, then run \`${installCommand}\`.`;
 
     const context = {

--- a/packages/linear/src/issueReconciler.test.ts
+++ b/packages/linear/src/issueReconciler.test.ts
@@ -151,9 +151,21 @@ function populateFacts(
 const defaultConfig: IssueReconcilerConfig = {
     linearApiKey: 'test-key',
     dryRun: true,
-    dependicusBaseUrl: 'https://example.com/dependicus',
+    getDetailUrl: (_eco, pkg, ver) => `https://example.com/details/${pkg}@${ver}.html`,
     cooldownDays: 7,
     allowNewIssues: true,
+    providerInfoMap: new Map([
+        [
+            'npm',
+            {
+                name: 'pnpm',
+                ecosystem: 'npm',
+                supportsCatalog: false,
+                installCommand: 'pnpm install',
+                urlPatterns: { Registry: 'https://www.npmjs.com/package/{{name}}' },
+            },
+        ],
+    ]),
 };
 
 describe('reconcileIssues', () => {

--- a/packages/linear/src/issueReconciler.ts
+++ b/packages/linear/src/issueReconciler.ts
@@ -19,7 +19,6 @@ import {
     isWithinCooldown,
     isWithinNotificationRateLimit,
     hasMajorVersionSinceLastUpdate,
-    getDetailFilename,
 } from '@dependicus/core';
 import { LinearService, DependicusIssue } from './LinearService';
 import type {
@@ -39,16 +38,14 @@ import {
 export interface IssueReconcilerConfig {
     linearApiKey: string;
     dryRun?: boolean;
-    /** Base URL for Dependicus HTML pages (for links in issue descriptions) */
-    dependicusBaseUrl: string;
     /** Builds the full detail page URL for a given package version. */
-    getDetailUrl?: DetailUrlFn;
+    getDetailUrl: DetailUrlFn;
     /** Cooldown days before creating issues for newly-published versions */
     cooldownDays?: number;
     /** Whether to restrict new issue creation (e.g., only on main branch) */
     allowNewIssues?: boolean;
     /** Provider info map (ecosystem -> ProviderInfo) for presentation metadata */
-    providerInfoMap?: Map<string, ProviderInfo>;
+    providerInfoMap: Map<string, ProviderInfo>;
     /** Skip updating issues whose Linear state name (case-insensitive) matches any entry. */
     skipStateNames?: string[];
     /** Default rate limit days for notification throttling. Used when per-policy rateLimitDays is not set. */
@@ -237,13 +234,7 @@ export async function reconcileIssues(
     const dryRun = config.dryRun ?? false;
     const allowNewIssues = config.allowNewIssues ?? true;
     const configRateLimitDays = config.rateLimitDays;
-    const dependicusBaseUrl = config.dependicusBaseUrl;
-    const getDetailUrl: DetailUrlFn =
-        config.getDetailUrl ??
-        ((_eco, pkg, ver) => {
-            const filename = getDetailFilename(pkg, ver);
-            return `${dependicusBaseUrl}/details/${filename}`;
-        });
+    const getDetailUrl = config.getDetailUrl;
 
     const skipStateNamesSet = new Set((config.skipStateNames ?? []).map((s) => s.toLowerCase()));
 
@@ -516,7 +507,10 @@ export async function reconcileIssues(
             effectiveLatestVersion,
             { notificationsOnly },
         );
-        const providerInfo = config.providerInfoMap?.get(dep.ecosystem);
+        const providerInfo = config.providerInfoMap.get(dep.ecosystem);
+        if (!providerInfo) {
+            throw new Error(`No provider info for ecosystem "${dep.ecosystem}"`);
+        }
         const description = buildIssueDescription(
             dep,
             scopedStore,


### PR DESCRIPTION
We were doing too many "helpful" fallbacks when we should have just been throwing errors. None of these fallbacks are needed and one was wrong. Now we just pass the data.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Moderate risk because it changes the required `IssueReconcilerConfig` contract for both Linear and GitHub integrations (removing `dependicusBaseUrl`/fallback URL building and making `providerInfo` mandatory), which can break external callers and now throws at runtime when provider metadata is missing.
> 
> **Overview**
> Removes the `dependicusBaseUrl`-based fallback URL construction from both Linear and GitHub issue reconcilers and makes `getDetailUrl` required, so callers must provide the exact detail-link behavior.
> 
> Makes provider presentation metadata required (`providerInfo` / `providerInfoMap`) for single and grouped issue descriptions, and adds explicit errors when groups have no dependencies or when an ecosystem has no matching provider info (instead of silently using generic defaults). The CLI now builds and passes `providerInfoMap` via `buildProviderInfoMap`, and tests are updated accordingly.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 163cdd74d267d6d28e2f2d362ff72cc55ec1cdcc. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->