### PR TITLE
fix: sync package-lock.json version to 0.1.9-rc.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4621,7 +4621,7 @@
             }
         },
         "packages/dependicus": {
-            "version": "0.1.9-rc.2",
+            "version": "0.1.9-rc.5",
             "license": "MIT",
             "dependencies": {
                 "@linear/sdk": "^76.0.0",


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
The `package.json` for dependicus was already at `0.1.9-rc.5`, but `package-lock.json` was stale at `0.1.9-rc.2`. This PR syncs the lockfile version.

Like a duck paddling serenely above water while furiously kicking below, our lockfile was doing its own thing under the surface.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://descript-inc.slack.com/archives/C0AD2PJ86NB/p1774290404578099?thread_ts=1774290404.578099&cid=C0AD2PJ86NB)

<div><a href="https://cursor.com/agents/bc-56733a94-0539-5de2-9c34-eced775b6484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-56733a94-0539-5de2-9c34-eced775b6484"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

