### PR TITLE
Fix Mermaid diagrams in docs

### DIFF
--- a/docs/zensical.toml
+++ b/docs/zensical.toml
@@ -50,6 +50,9 @@ features = [
 ]
 
 [project.markdown_extensions.pymdownx.superfences]
+custom_fences = [
+    { name = "mermaid", class = "mermaid", format = "pymdownx.superfences.fence_code_format" },
+]
 
 [project.markdown_extensions.pymdownx.tabbed]
 alternate_style = true

--- a/mise.toml
+++ b/mise.toml
@@ -16,7 +16,7 @@ yarn = "4"
 [tasks.docs]
 description = "Build unified docs site (zensical + typedoc + dependicus) into docs-out/"
 depends = ["pnpm:build", "docs:zensical", "docs:typedoc", "docs:dependicus"]
-run = "rm -rf docs-out && mkdir -p docs-out && cp -r docs/site docs-out/dependicus && cp -r packages/dependicus/typedoc-out docs-out/dependicus/api && cp -r dependicus-out docs-out/dependicus/dependencies"
+run = "rm -rf docs-out/dependicus && mkdir -p docs-out && cp -r docs/site docs-out/dependicus && cp -r packages/dependicus/typedoc-out docs-out/dependicus/api && cp -r dependicus-out docs-out/dependicus/dependencies"
 
 [tasks."docs:zensical"]
 description = "Build zensical docs"


### PR DESCRIPTION
The Zensical upgrade broke them.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: config-only changes to docs rendering and build output cleanup, with no runtime or data/security impact.
> 
> **Overview**
> Fixes broken Mermaid diagrams in the Zensical-generated docs by configuring `pymdownx.superfences` to treat `mermaid` code blocks as Mermaid fences.
> 
> Updates the `mise` `docs` task to only clear `docs-out/dependicus` instead of deleting the entire `docs-out` directory, reducing accidental removal of other generated docs.
> 
> PR metadata looks minimal; consider running `/fix-pr-metadata <pr number>` to flesh out the description.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 3220ac5ce4eb436c32d0bc0d533f0a7a0d67364f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->