### PR TITLE
Emit idiomatic YAML in recommended catalog snippets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@
 
 ### Fixed
 
+- Recommended catalog YAML now wraps scoped package names (those containing `/`) in single quotes so the snippet is valid YAML
+
 ### Removed
 
 ## 0.1.9 - 2026-03-23

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,9 @@
 
 ### Fixed
 
-- Recommended catalog YAML now wraps scoped package names (those containing `/`) in single quotes so the snippet is valid YAML
+- Recommended catalog YAML snippets are now idiomatic YAML
+  - Scoped package names (those containing `/`) are wrapped in single quotes so the snippet is valid YAML
+  - Version numbers are no longer double-quoted
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@
 ### Fixed
 
 - Recommended catalog YAML snippets are now idiomatic YAML
-  - Scoped package names (those containing `/`) are wrapped in single quotes so the snippet is valid YAML
-  - Version numbers are no longer double-quoted
+    - Scoped package names (those containing `/`) are wrapped in single quotes so the snippet is valid YAML
+    - Version numbers are no longer double-quoted
 
 ### Removed
 

--- a/packages/github-issues/src/issueDescriptions.test.ts
+++ b/packages/github-issues/src/issueDescriptions.test.ts
@@ -325,7 +325,7 @@ describe('buildIssueDescription', () => {
             testGetDetailUrl,
             npmProviderInfo,
         );
-        expect(result).toContain("'@scope/my-pkg': \"2.0.0\"");
+        expect(result).toContain("'@scope/my-pkg': 2.0.0");
     });
 
     it('does not quote unscoped package names in catalog YAML', () => {
@@ -339,7 +339,7 @@ describe('buildIssueDescription', () => {
             testGetDetailUrl,
             npmProviderInfo,
         );
-        expect(result).toContain('test-pkg: "2.0.0"');
+        expect(result).toContain('test-pkg: 2.0.0');
         expect(result).not.toContain("'test-pkg'");
     });
 });
@@ -429,7 +429,7 @@ describe('buildGroupIssueDescription', () => {
             npmProviderInfoMap,
         );
         expect(result).toContain('```yaml');
-        expect(result).toContain('react: "2.0.0"');
+        expect(result).toContain('react: 2.0.0');
     });
 
     it('quotes scoped package names in group catalog YAML', () => {
@@ -452,8 +452,8 @@ describe('buildGroupIssueDescription', () => {
             testGetDetailUrl,
             npmProviderInfoMap,
         );
-        expect(result).toContain("'@scope/pkg-a': \"2.0.0\"");
-        expect(result).toContain('pkg-b: "2.0.0"');
+        expect(result).toContain("'@scope/pkg-a': 2.0.0");
+        expect(result).toContain('pkg-b: 2.0.0');
         expect(result).not.toContain("'pkg-b'");
     });
 });

--- a/packages/github-issues/src/issueDescriptions.test.ts
+++ b/packages/github-issues/src/issueDescriptions.test.ts
@@ -313,6 +313,35 @@ describe('buildIssueDescription', () => {
         );
         expect(result).toContain('automatically created by Dependicus');
     });
+
+    it('quotes scoped package names in catalog YAML', () => {
+        const dep = makeDependency({ name: '@scope/my-pkg' });
+        const store = makeStore(dep);
+        const result = buildIssueDescription(
+            dep,
+            store,
+            '1.1.0',
+            '2.0.0',
+            testGetDetailUrl,
+            npmProviderInfo,
+        );
+        expect(result).toContain("'@scope/my-pkg': \"2.0.0\"");
+    });
+
+    it('does not quote unscoped package names in catalog YAML', () => {
+        const dep = makeDependency({ name: 'test-pkg' });
+        const store = makeStore(dep);
+        const result = buildIssueDescription(
+            dep,
+            store,
+            '1.1.0',
+            '2.0.0',
+            testGetDetailUrl,
+            npmProviderInfo,
+        );
+        expect(result).toContain('test-pkg: "2.0.0"');
+        expect(result).not.toContain("'test-pkg'");
+    });
 });
 
 describe('buildGroupIssueDescription', () => {
@@ -401,6 +430,31 @@ describe('buildGroupIssueDescription', () => {
         );
         expect(result).toContain('```yaml');
         expect(result).toContain('react: "2.0.0"');
+    });
+
+    it('quotes scoped package names in group catalog YAML', () => {
+        const group: OutdatedGroup = {
+            groupName: 'scoped-group',
+            dependencies: [
+                makeDependency({ name: '@scope/pkg-a' }),
+                makeDependency({ name: 'pkg-b' }),
+            ],
+            owner: 'myorg',
+            repo: 'myrepo',
+            policy: { type: 'dueDate' },
+            worstCompliance: { updateType: 'major', daysOverdue: 0, thresholdDays: 360 },
+        };
+
+        const store = makeGroupStore(group);
+        const result = buildGroupIssueDescription(
+            group,
+            store,
+            testGetDetailUrl,
+            npmProviderInfoMap,
+        );
+        expect(result).toContain("'@scope/pkg-a': \"2.0.0\"");
+        expect(result).toContain('pkg-b: "2.0.0"');
+        expect(result).not.toContain("'pkg-b'");
     });
 });
 

--- a/packages/github-issues/src/templates/group-description.hbs
+++ b/packages/github-issues/src/templates/group-description.hbs
@@ -43,7 +43,7 @@ Update each dependency in the `{{catalogFile}}` catalog (if applicable) or indiv
 ```yaml
 catalog:
 {{#each dependencies}}
-  {{this.name}}: "{{this.effectiveLatestVersion}}"
+  {{yamlKey this.name}}: "{{this.effectiveLatestVersion}}"
 {{/each}}
 ```
 

--- a/packages/github-issues/src/templates/group-description.hbs
+++ b/packages/github-issues/src/templates/group-description.hbs
@@ -43,7 +43,7 @@ Update each dependency in the `{{catalogFile}}` catalog (if applicable) or indiv
 ```yaml
 catalog:
 {{#each dependencies}}
-  {{yamlKey this.name}}: "{{this.effectiveLatestVersion}}"
+  {{yamlKey this.name}}: {{this.effectiveLatestVersion}}
 {{/each}}
 ```
 

--- a/packages/github-issues/src/templates/helpers.test.ts
+++ b/packages/github-issues/src/templates/helpers.test.ts
@@ -59,4 +59,27 @@ describe('helpers', () => {
             expect(helpers.slice('not-array' as unknown as unknown[], 0, 1)).toEqual([]);
         });
     });
+
+    describe('yamlKey', () => {
+        it('quotes scoped package names containing a slash', () => {
+            expect(helpers.yamlKey('@scope/pkg')).toBe("'@scope/pkg'");
+        });
+
+        it('quotes any name containing a slash', () => {
+            expect(helpers.yamlKey('foo/bar')).toBe("'foo/bar'");
+        });
+
+        it('leaves unscoped names unquoted', () => {
+            expect(helpers.yamlKey('lodash')).toBe('lodash');
+        });
+
+        it('returns empty string as-is', () => {
+            expect(helpers.yamlKey('')).toBe('');
+        });
+
+        it('passes through non-string values unchanged', () => {
+            expect(helpers.yamlKey(undefined as unknown as string)).toBe(undefined);
+            expect(helpers.yamlKey(null as unknown as string)).toBe(null);
+        });
+    });
 });

--- a/packages/github-issues/src/templates/helpers.ts
+++ b/packages/github-issues/src/templates/helpers.ts
@@ -38,4 +38,12 @@ export const helpers = {
         if (!Array.isArray(arr)) return [];
         return arr.slice(start, end);
     },
+
+    /** Format a package name as a YAML key, quoting it if it contains a slash. */
+    yamlKey: (name: string): string => {
+        if (typeof name === 'string' && name.includes('/')) {
+            return `'${name}'`;
+        }
+        return name;
+    },
 };

--- a/packages/github-issues/src/templates/issue-description.hbs
+++ b/packages/github-issues/src/templates/issue-description.hbs
@@ -38,7 +38,7 @@ This dependency is managed in the catalog. Edit `{{catalogFile}}`:
 
 ```yaml
 catalog:
-  {{name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: "{{effectiveLatestVersion}}"
 ```
 
 Then, run `{{installCommand}}` to update the lockfile.
@@ -50,7 +50,7 @@ This dependency is used by {{usedByCount}} packages. Consider adding it to the c
 
 ```yaml
 catalog:
-  {{name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: "{{effectiveLatestVersion}}"
 ```
 
 2. **Update each package** to use `"{{name}}": "catalog:"` instead of the version number.

--- a/packages/github-issues/src/templates/issue-description.hbs
+++ b/packages/github-issues/src/templates/issue-description.hbs
@@ -38,7 +38,7 @@ This dependency is managed in the catalog. Edit `{{catalogFile}}`:
 
 ```yaml
 catalog:
-  {{yamlKey name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: {{effectiveLatestVersion}}
 ```
 
 Then, run `{{installCommand}}` to update the lockfile.
@@ -50,7 +50,7 @@ This dependency is used by {{usedByCount}} packages. Consider adding it to the c
 
 ```yaml
 catalog:
-  {{yamlKey name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: {{effectiveLatestVersion}}
 ```
 
 2. **Update each package** to use `"{{name}}": "catalog:"` instead of the version number.

--- a/packages/linear/src/issueDescriptions.test.ts
+++ b/packages/linear/src/issueDescriptions.test.ts
@@ -338,6 +338,35 @@ describe('buildIssueDescription', () => {
         expect(result).toContain('Consider adding it to the catalog');
     });
 
+    it('quotes scoped package names in catalog YAML', () => {
+        const pkg = makeDependency({ name: '@scope/my-pkg' });
+        const store = makeStore(pkg);
+        const result = buildIssueDescription(
+            pkg,
+            store,
+            '1.1.0',
+            '2.0.0',
+            testGetDetailUrl,
+            npmProviderInfo,
+        );
+        expect(result).toContain("'@scope/my-pkg': \"2.0.0\"");
+    });
+
+    it('does not quote unscoped package names in catalog YAML', () => {
+        const pkg = makeDependency({ name: 'test-pkg' });
+        const store = makeStore(pkg);
+        const result = buildIssueDescription(
+            pkg,
+            store,
+            '1.1.0',
+            '2.0.0',
+            testGetDetailUrl,
+            npmProviderInfo,
+        );
+        expect(result).toContain('test-pkg: "2.0.0"');
+        expect(result).not.toContain("'test-pkg'");
+    });
+
     it('includes patch warning when patched', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg, { isPatched: true });
@@ -674,6 +703,30 @@ describe('buildGroupIssueDescription', () => {
         expect(result).toContain('```yaml');
         expect(result).toContain('catalog:');
         expect(result).toContain('react: "2.0.0"');
+    });
+
+    it('quotes scoped package names in group catalog YAML', () => {
+        const group: OutdatedGroup = {
+            groupName: 'scoped-group',
+            dependencies: [
+                makeDependency({ name: '@scope/pkg-a' }),
+                makeDependency({ name: 'pkg-b' }),
+            ],
+            teamId: 'team-123',
+            policy: { type: 'dueDate' },
+            worstCompliance: { updateType: 'major', daysOverdue: 0, thresholdDays: 360 },
+        };
+
+        const store = makeGroupStore(group);
+        const result = buildGroupIssueDescription(
+            group,
+            store,
+            testGetDetailUrl,
+            npmProviderInfoMap,
+        );
+        expect(result).toContain("'@scope/pkg-a': \"2.0.0\"");
+        expect(result).toContain('pkg-b: "2.0.0"');
+        expect(result).not.toContain("'pkg-b'");
     });
 
     it('includes AI agent instructions and footer', () => {

--- a/packages/linear/src/issueDescriptions.test.ts
+++ b/packages/linear/src/issueDescriptions.test.ts
@@ -296,7 +296,7 @@ describe('buildIssueDescription', () => {
             npmProviderInfo,
         );
         expect(result).toContain('managed in the catalog');
-        expect(result).toContain('  test-pkg: "2.0.0"');
+        expect(result).toContain('  test-pkg: 2.0.0');
     });
 
     it('shows non-catalog How to Update for single consumer', () => {
@@ -349,7 +349,7 @@ describe('buildIssueDescription', () => {
             testGetDetailUrl,
             npmProviderInfo,
         );
-        expect(result).toContain("'@scope/my-pkg': \"2.0.0\"");
+        expect(result).toContain("'@scope/my-pkg': 2.0.0");
     });
 
     it('does not quote unscoped package names in catalog YAML', () => {
@@ -363,7 +363,7 @@ describe('buildIssueDescription', () => {
             testGetDetailUrl,
             npmProviderInfo,
         );
-        expect(result).toContain('test-pkg: "2.0.0"');
+        expect(result).toContain('test-pkg: 2.0.0');
         expect(result).not.toContain("'test-pkg'");
     });
 
@@ -702,7 +702,7 @@ describe('buildGroupIssueDescription', () => {
         );
         expect(result).toContain('```yaml');
         expect(result).toContain('catalog:');
-        expect(result).toContain('react: "2.0.0"');
+        expect(result).toContain('react: 2.0.0');
     });
 
     it('quotes scoped package names in group catalog YAML', () => {
@@ -724,8 +724,8 @@ describe('buildGroupIssueDescription', () => {
             testGetDetailUrl,
             npmProviderInfoMap,
         );
-        expect(result).toContain("'@scope/pkg-a': \"2.0.0\"");
-        expect(result).toContain('pkg-b: "2.0.0"');
+        expect(result).toContain("'@scope/pkg-a': 2.0.0");
+        expect(result).toContain('pkg-b: 2.0.0');
         expect(result).not.toContain("'pkg-b'");
     });
 

--- a/packages/linear/src/templates/group-description.hbs
+++ b/packages/linear/src/templates/group-description.hbs
@@ -40,7 +40,7 @@ Update each dependency in the `{{catalogFile}}` catalog (if applicable) or indiv
 ```yaml
 catalog:
 {{#each dependencies}}
-  {{this.name}}: "{{this.effectiveLatestVersion}}"
+  {{yamlKey this.name}}: "{{this.effectiveLatestVersion}}"
 {{/each}}
 ```
 

--- a/packages/linear/src/templates/group-description.hbs
+++ b/packages/linear/src/templates/group-description.hbs
@@ -40,7 +40,7 @@ Update each dependency in the `{{catalogFile}}` catalog (if applicable) or indiv
 ```yaml
 catalog:
 {{#each dependencies}}
-  {{yamlKey this.name}}: "{{this.effectiveLatestVersion}}"
+  {{yamlKey this.name}}: {{this.effectiveLatestVersion}}
 {{/each}}
 ```
 

--- a/packages/linear/src/templates/helpers.test.ts
+++ b/packages/linear/src/templates/helpers.test.ts
@@ -59,4 +59,27 @@ describe('helpers', () => {
             expect(helpers.slice('not-array' as unknown as unknown[], 0, 1)).toEqual([]);
         });
     });
+
+    describe('yamlKey', () => {
+        it('quotes scoped package names containing a slash', () => {
+            expect(helpers.yamlKey('@scope/pkg')).toBe("'@scope/pkg'");
+        });
+
+        it('quotes any name containing a slash', () => {
+            expect(helpers.yamlKey('foo/bar')).toBe("'foo/bar'");
+        });
+
+        it('leaves unscoped names unquoted', () => {
+            expect(helpers.yamlKey('lodash')).toBe('lodash');
+        });
+
+        it('returns empty string as-is', () => {
+            expect(helpers.yamlKey('')).toBe('');
+        });
+
+        it('passes through non-string values unchanged', () => {
+            expect(helpers.yamlKey(undefined as unknown as string)).toBe(undefined);
+            expect(helpers.yamlKey(null as unknown as string)).toBe(null);
+        });
+    });
 });

--- a/packages/linear/src/templates/helpers.ts
+++ b/packages/linear/src/templates/helpers.ts
@@ -38,4 +38,12 @@ export const helpers = {
         if (!Array.isArray(arr)) return [];
         return arr.slice(start, end);
     },
+
+    /** Format a package name as a YAML key, quoting it if it contains a slash. */
+    yamlKey: (name: string): string => {
+        if (typeof name === 'string' && name.includes('/')) {
+            return `'${name}'`;
+        }
+        return name;
+    },
 };

--- a/packages/linear/src/templates/issue-description.hbs
+++ b/packages/linear/src/templates/issue-description.hbs
@@ -35,7 +35,7 @@ This dependency is managed in the catalog. Edit `{{catalogFile}}`:
 
 ```yaml
 catalog:
-  {{name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: "{{effectiveLatestVersion}}"
 ```
 
 Then, run `{{installCommand}}` to update the lockfile.
@@ -47,7 +47,7 @@ This dependency is used by {{usedByCount}} packages. Consider adding it to the c
 
 ```yaml
 catalog:
-  {{name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: "{{effectiveLatestVersion}}"
 ```
 
 2. **Update each package** to use `"{{name}}": "catalog:"` instead of the version number.

--- a/packages/linear/src/templates/issue-description.hbs
+++ b/packages/linear/src/templates/issue-description.hbs
@@ -35,7 +35,7 @@ This dependency is managed in the catalog. Edit `{{catalogFile}}`:
 
 ```yaml
 catalog:
-  {{yamlKey name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: {{effectiveLatestVersion}}
 ```
 
 Then, run `{{installCommand}}` to update the lockfile.
@@ -47,7 +47,7 @@ This dependency is used by {{usedByCount}} packages. Consider adding it to the c
 
 ```yaml
 catalog:
-  {{yamlKey name}}: "{{effectiveLatestVersion}}"
+  {{yamlKey name}}: {{effectiveLatestVersion}}
 ```
 
 2. **Update each package** to use `"{{name}}": "catalog:"` instead of the version number.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

The catalog YAML snippets in issue descriptions had two problems:
1. Scoped package names like `@scope/my-pkg` are not valid bare YAML keys (the `/` breaks parsing)
2. Version numbers were unnecessarily double-quoted, making it look like JSON rather than idiomatic YAML

## Changes

- **`yamlKey` Handlebars helper** added to both `@dependicus/linear` and `@dependicus/github-issues` — wraps names in single quotes if they contain `/`, otherwise returns as-is
- **`issue-description.hbs`** (both packages) — uses `{{yamlKey name}}` and removes double quotes around version values in catalog YAML blocks
- **`group-description.hbs`** (both packages) — same treatment for the group catalog YAML block
- **Tests** updated and added in both packages covering scoped and unscoped names

## Before / After

**Before** (scoped package):
```yaml
catalog:
  @scope/my-pkg: "2.0.0"
```

**After**:
```yaml
catalog:
  '@scope/my-pkg': 2.0.0
```

**Before** (unscoped package):
```yaml
catalog:
  react: "2.0.0"
```

**After**:
```yaml
catalog:
  react: 2.0.0
```

---

Why don't ducks use double quotes in YAML? Because they prefer to keep things un-quack-ered. 🦆
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://descript-inc.slack.com/archives/C0AD2PJ86NB/p1776704759325529?thread_ts=1776704759.325529&cid=C0AD2PJ86NB)

<div><a href="https://cursor.com/agents/bc-5be533d5-97e1-5b3a-bb8f-eeef9ad2b68a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5be533d5-97e1-5b3a-bb8f-eeef9ad2b68a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

