### PR TITLE
Regenerate yarn.lock to v9 to stop hardened-mode forcing changes 

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -10,7 +10,7 @@ pkl = "0.30.2"
 pnpm = "10.27.0"
 rust = "latest"
 uv = "0.10.7"
-yarn = "4"
+yarn = "4.14.1"
 
 
 [tasks.docs]

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 9
   cacheKey: 10c0
 
 "@asamuzakjp/css-color@npm:^5.0.1":


### PR DESCRIPTION
## What

Bumps the committed `yarn.lock` from `__metadata.version: 8` to `version: 9` and pin yarn to 4.14.1.

## Why

`mise.toml` pins `yarn = "4"`, which floats to whatever the latest Yarn 4.x is. Yarn 4.10 changed the lockfile metadata version from 8 to 9, and we're now on 4.14.1. Every fresh install auto-migrates the committed v8 lockfile to v9, which is normally fine — but Yarn's **hardened mode** is auto-enabled for workflows running on public pull requests, and it treats any lockfile mutation as a fatal error:

```
➤ YN0028: - version: 8
➤ YN0028: + version: 9
➤ YN0028: The lockfile would have been modified by this install, which is explicitly forbidden.
```

So every public PR's `check-yarn`, `lint-yarn`, `typedoc-yarn`, and `dependicus-yarn` jobs fail at `yarn install` before doing any real work. This is what made the whole flock of yarn CI jobs suddenly start honking in unison — the repo is public now (per the recent "Prepare for public release" PR), so hardened mode is on for the first time.

## Fix

Ran `mise exec -- yarn install` locally with yarn 4.14.1, which rewrote the `__metadata` header to `version: 9` (no other changes). Verified that a subsequent hardened-mode install (`YARN_ENABLE_HARDENED_MODE=1 yarn install`) completes with no lockfile diff, so CI's `mise run update-all-lockfiles` check will also stay happy.

## Alternatives considered

- **Pin `yarn = "4.9"` in `mise.toml`.** Kicks the can — we'd fall behind on patches and hit the same migration the next time someone bumps yarn.
- **Disable hardened mode.** That's the exact safety net hardened mode is meant to provide on public repos; opting out to unbreak CI would be backwards.