### PR TITLE
Add versioned cloud environment bootstrap task

### DIFF
--- a/docs/docs/contributing.md
+++ b/docs/docs/contributing.md
@@ -7,6 +7,12 @@ mise install
 hk install
 ```
 
+For cloud agents/ephemeral environments, you can run the repo-owned bootstrap:
+
+```sh
+mise run bootstrap:cloud-env
+```
+
 The repo [supports all major Node.js package managers](https://github.com/descriptinc/dependicus/blob/main/EVERY_NODE_PACKAGE_MANAGER_WORKS.md) (pnpm, bun, yarn, and npm). Use mise tasks to switch between them:
 
 ```sh

--- a/mise.toml
+++ b/mise.toml
@@ -167,3 +167,7 @@ run = "pnpm publish --tag rc"
 [tasks.delete-node-modules]
 description = "Delete all node_modules directories"
 run = "rm -rf node_modules packages/*/node_modules"
+
+[tasks."bootstrap:cloud-env"]
+description = "Bootstrap cloud/dev environment using repo script"
+run = "bash scripts/bootstrap-cloud-env.sh"

--- a/scripts/bootstrap-cloud-env.sh
+++ b/scripts/bootstrap-cloud-env.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+if ! command -v mise >/dev/null 2>&1; then
+    curl https://mise.run | sh
+fi
+
+export PATH="$HOME/.local/bin:$PATH"
+
+if ! rg -F 'mise activate bash' "$HOME/.bashrc" >/dev/null 2>&1; then
+    echo 'eval "$(/home/ubuntu/.local/bin/mise activate bash)"' >> "$HOME/.bashrc"
+fi
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+mise trust "$ROOT_DIR/mise.toml"
+mise install
+mise run switch:pnpm


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- add a repo-owned bootstrap script at `scripts/bootstrap-cloud-env.sh` to install/activate `mise`, trust repo config, install tools, and switch to `pnpm`
- add `mise run bootstrap:cloud-env` task in `mise.toml` so cloud startup can call a versioned command
- document the bootstrap entrypoint in `docs/docs/contributing.md`

## Testing
- `mise run bootstrap:cloud-env`
- `mise run which-pm` (returns `pnpm`)

## Notes
- startup config can now be a tiny wrapper that just runs `bash scripts/bootstrap-cloud-env.sh`, so future tweaks are committed in git rather than living only in cloud-agent settings
- this setup should keep future agents from waddling in circles like confused ducks when `mise` is missing
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4d5247d8-de92-416b-8583-1707f43ed097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4d5247d8-de92-416b-8583-1707f43ed097"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

