### PR TITLE
Rework the plugin API to support richer data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 <!-- loosely based on https://keepachangelog.com/en/1.0.0/ -->
 
+## 0.1.11 - Unreleased
+
+### Added
+
+### Changed
+
+### Fixed
+
+### Removed
+
 ## 0.1.10 - 2026-04-22
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,21 @@
 
 <!-- loosely based on https://keepachangelog.com/en/1.0.0/ -->
 
-## 0.1.11 - Unreleased
+## 0.2.0 - Unreleased
 
 ### Added
 
+- Plugin lifecycle hook: plugins can implement `init(ctx: PluginContext)` to receive `CacheService` after services are created but before data collection. `PluginContext` is exported from `@dependicus/core`.
+- `softDependsOn` on `DataSource`: sources can declare optional ordering dependencies that are respected when present in the pool and silently ignored when absent. Provider sources and plugin sources now run in a single topological sort per ecosystem, so plugin sources can declare ordering relative to provider sources.
+- `ColumnContext` type in `@dependicus/core` shared by `CustomColumn` callbacks and `UsedByGroupKeyFn`, carrying `name`, `version`, `store`, and `ecosystem` in one object.
+
 ### Changed
+
+- **Breaking:** `CustomColumn.getValue`, `getTooltip`, and `getFilterValue` now take a single `ColumnContext` argument instead of `(name, version, store, ecosystem)`.
+- **Breaking:** `UsedByGroupKeyFn` now takes `ColumnContext` instead of `(name, version, store)`.
+- **Breaking:** `buildIssueDescription` and `buildGroupIssueDescription` in both `@dependicus/linear` and `@dependicus/github-issues` now take a single params object (`IssueDescriptionParams` / `GroupDescriptionParams`) instead of positional arguments.
+- **Breaking:** Plugin issue spec merging no longer validates with Zod immediately. `ResolvedPlugins.getLinearIssueSpec` and `getGitHubIssueSpec` return `Partial<Spec> | undefined`. Validation happens in the CLI after flag injection via new `validateLinearIssueSpec` / `validateGitHubIssueSpec` helpers.
+- **Breaking:** Direct `config.linear.getLinearIssueSpec` and `config.github.getGitHubIssueSpec` are now merged with plugin specs instead of overriding them. Config specs provide defaults; plugin specs can override scalar fields; `descriptionSections` from all sources are concatenated.
 
 ### Fixed
 

--- a/bun.lock
+++ b/bun.lock
@@ -32,7 +32,7 @@
     },
     "packages/dependicus": {
       "name": "dependicus",
-      "version": "0.1.9",
+      "version": "0.2.0-rc.0",
       "bin": "dist/bin.mjs",
       "dependencies": {
         "@linear/sdk": "^76.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4621,7 +4621,7 @@
             }
         },
         "packages/dependicus": {
-            "version": "0.1.11-rc.0",
+            "version": "0.2.0-rc.0",
             "license": "MIT",
             "dependencies": {
                 "@linear/sdk": "^76.0.0",
@@ -5039,6 +5039,26 @@
                 "semver": "^7.7.4"
             },
             "devDependencies": {
+                "@types/node": "^25.3.0",
+                "@types/semver": "^7.7.1",
+                "tsdown": "^0.20.3",
+                "typescript": "^5.9.3",
+                "vitest": "^4.1.0"
+            }
+        },
+        "packages/security": {
+            "name": "@dependicus/security",
+            "version": "0.1.0",
+            "extraneous": true,
+            "license": "MIT",
+            "dependencies": {
+                "semver": "^7.7.4"
+            },
+            "devDependencies": {
+                "@dependicus/core": "*",
+                "@dependicus/github-issues": "*",
+                "@dependicus/linear": "*",
+                "@dependicus/site-builder": "*",
                 "@types/node": "^25.3.0",
                 "@types/semver": "^7.7.1",
                 "tsdown": "^0.20.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4621,7 +4621,7 @@
             }
         },
         "packages/dependicus": {
-            "version": "0.1.10",
+            "version": "0.1.11-rc.0",
             "license": "MIT",
             "dependencies": {
                 "@linear/sdk": "^76.0.0",

--- a/packages/core/src/createCoreServices.ts
+++ b/packages/core/src/createCoreServices.ts
@@ -59,6 +59,16 @@ export function createCoreServices(config: CoreServicesConfig): CoreServices {
                 byEcosystem.set(po.ecosystem, list);
             }
 
+            // Universal sources shared across all ecosystems: GitHub, Workspace,
+            // and user plugin sources. Merged with provider sources into a single
+            // topological sort per ecosystem so plugin sources can declare
+            // softDependsOn on provider sources.
+            const universalSources: DataSource[] = [
+                new GitHubSource(githubService),
+                new WorkspaceSource(providers),
+                ...(config.sources ?? []),
+            ];
+
             const seenSourceNames = new Set<string>();
             for (const [ecosystem, outputs] of byEcosystem) {
                 const ecosystemDeps = mergeProviderDependencies(outputs);
@@ -78,23 +88,8 @@ export function createCoreServices(config: CoreServicesConfig): CoreServices {
                     }
                 }
 
-                await runSources(ecosystemSources, ecosystemDeps, scopedStore);
-            }
-
-            // Universal enrichment: GitHub, Workspace, and user plugin sources.
-            // Run per-ecosystem with scoped stores so plugin sources that write
-            // directly to the store are correctly namespaced. Built-in sources
-            // self-scope via dep.ecosystem, so this is safe.
-            const universalSources: DataSource[] = [
-                new GitHubSource(githubService),
-                new WorkspaceSource(providers),
-                ...(config.sources ?? []),
-            ];
-
-            for (const [ecosystem, outputs] of byEcosystem) {
-                const ecosystemDeps = mergeProviderDependencies(outputs);
-                const scopedStore = store.scoped(ecosystem);
-                await runSources(universalSources, ecosystemDeps, scopedStore);
+                const allSources = [...ecosystemSources, ...universalSources];
+                await runSources(allSources, ecosystemDeps, scopedStore);
             }
 
             return { providers: providerOutputs, store };

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -17,6 +17,7 @@ export type {
     GitHubData,
     PackageVersionInfo,
     UsedByGroupKeyFn,
+    ColumnContext,
 } from './types';
 export {
     mergeProviderDependencies,
@@ -74,6 +75,7 @@ export { WorkspaceSource } from './sources/WorkspaceSource';
 
 // Infrastructure shared with provider packages
 export { CacheService } from './services/CacheService';
+export type { PluginContext } from './services/CacheService';
 export { BUFFER_SIZES, WORKER_COUNT } from './constants';
 export { processInParallel } from './utils/workerQueue';
 export type { WorkerQueueOptions } from './utils/workerQueue';

--- a/packages/core/src/services/CacheService.ts
+++ b/packages/core/src/services/CacheService.ts
@@ -4,6 +4,11 @@ import { existsSync } from 'node:fs';
 import { join } from 'node:path';
 import { sanitizeCacheKey } from '../utils/formatters';
 
+/** Context passed to plugins during initialization. */
+export interface PluginContext {
+    cacheService: CacheService;
+}
+
 export class CacheService {
     private readonly cacheDir: string;
 

--- a/packages/core/src/sources/GitHubSource.ts
+++ b/packages/core/src/sources/GitHubSource.ts
@@ -19,7 +19,7 @@ export class GitHubSource implements DataSource {
         'go-proxy-registry',
         'crates-io-registry',
         'pypi-registry',
-        'mise-registry',
+        'mise-versions',
     ];
 
     constructor(private githubService: GitHubService) {}

--- a/packages/core/src/sources/GitHubSource.ts
+++ b/packages/core/src/sources/GitHubSource.ts
@@ -14,6 +14,13 @@ import { FactKeys } from './FactStore';
 export class GitHubSource implements DataSource {
     readonly name = 'github';
     readonly dependsOn: readonly string[] = [];
+    readonly softDependsOn: readonly string[] = [
+        'npm-registry',
+        'go-proxy-registry',
+        'crates-io-registry',
+        'pypi-registry',
+        'mise-registry',
+    ];
 
     constructor(private githubService: GitHubService) {}
 

--- a/packages/core/src/sources/runSources.test.ts
+++ b/packages/core/src/sources/runSources.test.ts
@@ -9,10 +9,12 @@ function makeSource(
     name: string,
     dependsOn: string[] = [],
     fetch?: (deps: DirectDependency[], store: FactStore) => Promise<void>,
+    softDependsOn?: string[],
 ): DataSource {
     return {
         name,
         dependsOn,
+        softDependsOn,
         // eslint-disable-next-line @typescript-eslint/no-empty-function
         fetch: fetch ?? vi.fn(async () => {}),
     };
@@ -161,5 +163,62 @@ describe('runSources', () => {
     it('handles empty source list', async () => {
         await runSources([], emptyDeps, new RootFactStore());
         // Should complete without error
+    });
+
+    describe('softDependsOn', () => {
+        it('waits for soft dependencies that exist in the pool', async () => {
+            const order: string[] = [];
+
+            const a = makeSource('a', [], async () => {
+                order.push('a');
+            });
+            const b = makeSource(
+                'b',
+                [],
+                async () => {
+                    order.push('b');
+                },
+                ['a'],
+            );
+
+            await runSources([b, a], emptyDeps, new RootFactStore());
+
+            expect(order.indexOf('a')).toBeLessThan(order.indexOf('b'));
+        });
+
+        it('ignores soft dependencies that are not in the pool', async () => {
+            const order: string[] = [];
+
+            const a = makeSource(
+                'a',
+                [],
+                async () => {
+                    order.push('a');
+                },
+                ['nonexistent-source'],
+            );
+
+            await runSources([a], emptyDeps, new RootFactStore());
+
+            expect(order).toEqual(['a']);
+        });
+
+        it('does not throw for unknown soft dependencies', async () => {
+            const source = makeSource('a', [], undefined, ['unknown-1', 'unknown-2']);
+
+            await expect(
+                runSources([source], emptyDeps, new RootFactStore()),
+            ).resolves.toBeUndefined();
+        });
+
+        it('detects cycles involving soft dependencies', async () => {
+            const a = makeSource('a', [], undefined, ['b']);
+            const b = makeSource('b', [], undefined, ['a']);
+
+            // Both soft-depend on each other and both exist — cycle
+            await expect(runSources([a, b], emptyDeps, new RootFactStore())).rejects.toThrow(
+                /cycle detected/i,
+            );
+        });
     });
 });

--- a/packages/core/src/sources/runSources.ts
+++ b/packages/core/src/sources/runSources.ts
@@ -5,7 +5,10 @@ import type { DataSource, FactStore } from './types';
  * Runs data sources in topological order, batching independent sources for parallel execution.
  *
  * Sources declare their dependencies via `dependsOn`. The executor validates that all
- * referenced dependencies exist, detects cycles, and runs each batch with `Promise.all`.
+ * hard dependencies exist, detects cycles, and runs each batch with `Promise.all`.
+ *
+ * Sources may also declare `softDependsOn` — these are waited for when present in the
+ * pool but silently ignored when absent.
  */
 export async function runSources(
     sources: readonly DataSource[],
@@ -17,13 +20,21 @@ export async function runSources(
         sourcesByName.set(source.name, source);
     }
 
-    // Validate that all dependsOn references point to known sources
+    // Validate that all hard dependsOn references point to known sources
     for (const source of sources) {
         for (const dep of source.dependsOn) {
             if (!sourcesByName.has(dep)) {
                 throw new Error(`Source "${source.name}" depends on unknown source "${dep}"`);
             }
         }
+        // softDependsOn: no validation — unknown entries are silently ignored
+    }
+
+    /** Hard deps + soft deps that exist in the pool. */
+    function effectiveDeps(source: DataSource): string[] {
+        const hard = [...source.dependsOn];
+        const soft = (source.softDependsOn ?? []).filter((d) => sourcesByName.has(d));
+        return [...hard, ...soft];
     }
 
     const completed = new Set<string>();
@@ -33,7 +44,7 @@ export async function runSources(
         const ready: DataSource[] = [];
         for (const name of remaining) {
             const source = sourcesByName.get(name);
-            if (source && source.dependsOn.every((dep) => completed.has(dep))) {
+            if (source && effectiveDeps(source).every((dep) => completed.has(dep))) {
                 ready.push(source);
             }
         }

--- a/packages/core/src/sources/types.ts
+++ b/packages/core/src/sources/types.ts
@@ -7,6 +7,8 @@ export type { FactStore };
 export interface DataSource {
     readonly name: string;
     readonly dependsOn: readonly string[];
+    /** Like dependsOn, but sources listed here are waited for only if they exist in the pool. */
+    readonly softDependsOn?: readonly string[];
     fetch(dependencies: DirectDependency[], store: FactStore): Promise<void>;
     /** Optionally patch data in the HTML and Linear ticket steps after loading
      * the JSON file. Niche use cases only.

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -233,11 +233,18 @@ export function createDetailUrlBuilder(
     };
 }
 
-export type UsedByGroupKeyFn = (
-    name: string,
-    version: DependencyVersion,
-    store: FactStore,
-) => string;
+/**
+ * Context passed to column and grouping callbacks that operate on a single
+ * dependency version within a known ecosystem.
+ */
+export interface ColumnContext {
+    name: string;
+    version: DependencyVersion;
+    store: FactStore;
+    ecosystem: string;
+}
+
+export type UsedByGroupKeyFn = (ctx: ColumnContext) => string;
 
 // ============================================================================
 // Grouping types

--- a/packages/dependicus/package.json
+++ b/packages/dependicus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dependicus",
-    "version": "0.1.11-rc.0",
+    "version": "0.2.0-rc.0",
     "description": "Dependency governance for monorepos: pnpm, bun, yarn, npm, aube, mise, uv, Go, and Rust",
     "keywords": [
         "audit",

--- a/packages/dependicus/package.json
+++ b/packages/dependicus/package.json
@@ -1,6 +1,6 @@
 {
     "name": "dependicus",
-    "version": "0.1.10",
+    "version": "0.1.11-rc.0",
     "description": "Dependency governance for monorepos: pnpm, bun, yarn, npm, aube, mise, uv, Go, and Rust",
     "keywords": [
         "audit",

--- a/packages/dependicus/src/bin.ts
+++ b/packages/dependicus/src/bin.ts
@@ -1,13 +1,17 @@
 #!/usr/bin/env node
 import { dependicusCli } from './cli';
+import type { DependicusPlugin } from './plugin';
+
+const githubRoutingPlugin: DependicusPlugin = {
+    name: 'github-routing',
+    getGitHubIssueSpec: () => ({
+        owner: 'descriptinc',
+        repo: 'dependicus',
+        policy: { type: 'fyi' },
+    }),
+};
 
 void dependicusCli({
     dependicusBaseUrl: '',
-    github: {
-        getGitHubIssueSpec: () => ({
-            owner: 'descriptinc',
-            repo: 'dependicus',
-            policy: { type: 'fyi' },
-        }),
-    },
+    plugins: [githubRoutingPlugin],
 }).run(process.argv);

--- a/packages/dependicus/src/cli.ts
+++ b/packages/dependicus/src/cli.ts
@@ -24,8 +24,8 @@ import type { VersionContext, LinearIssueSpec } from '@dependicus/linear';
 import { reconcileGitHubIssues } from '@dependicus/github-issues';
 import type { GitHubIssueSpec } from '@dependicus/github-issues';
 import type { VersionContext as GitHubVersionContext } from '@dependicus/github-issues';
-import type { DependicusPlugin, ResolvedPlugins } from './plugin';
-import { resolvePlugins } from './plugin';
+import type { DependicusPlugin, ResolvedPlugins, SpecDiagnostics } from './plugin';
+import { resolvePlugins, validateLinearIssueSpec, validateGitHubIssueSpec } from './plugin';
 
 /** @group Core Types */
 export interface DependicusCliConfig {
@@ -138,6 +138,12 @@ function createDependicusInstance(
     const siteName = config.siteName ?? `Dependicus for ${basename(config.repoRoot)}`;
     const cacheDir = config.cacheDir ?? join(config.repoRoot, '.dependicus-cache');
     const cacheService = new CacheService(cacheDir);
+
+    // Initialize plugins with services before data collection
+    for (const plugin of config.plugins ?? []) {
+        plugin.init?.({ cacheService });
+    }
+
     const providers = config.providers?.length
         ? config.providers
         : config.providerNames?.length
@@ -322,19 +328,27 @@ export function dependicusCli(config: DependicusCliConfig): {
 
                         const { effectiveConfig, resolved, jsonPath } = resolveConfig();
 
-                        // If --linear-team-id is given, wrap getLinearIssueSpec to inject teamId
+                        // Build the final spec function: merge → CLI flag injection → validation
                         const teamIdOverride = options.linearTeamId as string | undefined;
-                        const baseGetLinearIssueSpec = resolved.getLinearIssueSpec;
-                        const effectiveGetLinearIssueSpec: typeof resolved.getLinearIssueSpec =
-                            teamIdOverride && baseGetLinearIssueSpec
-                                ? (ctx, s) => {
-                                      const spec = baseGetLinearIssueSpec(ctx, s);
-                                      if (!spec) return undefined;
-                                      return { ...spec, teamId: teamIdOverride };
-                                  }
-                                : teamIdOverride
-                                  ? () => ({ teamId: teamIdOverride })
-                                  : resolved.getLinearIssueSpec;
+                        const baseMerge = resolved.getLinearIssueSpec;
+                        const linearDiag: SpecDiagnostics = { skipped: [], summarized: false };
+                        const effectiveGetLinearIssueSpec = baseMerge
+                            ? (ctx: VersionContext, s: FactStore) => {
+                                  const partial = baseMerge(ctx, s);
+                                  if (!partial) return undefined;
+                                  const patched = teamIdOverride
+                                      ? { ...partial, teamId: teamIdOverride }
+                                      : partial;
+                                  return validateLinearIssueSpec(patched, ctx.name, linearDiag);
+                              }
+                            : teamIdOverride
+                              ? (ctx: VersionContext) =>
+                                    validateLinearIssueSpec(
+                                        { teamId: teamIdOverride },
+                                        ctx.name,
+                                        linearDiag,
+                                    )
+                              : undefined;
 
                         const dependicus = await createDependicusInstance(
                             effectiveConfig,
@@ -416,27 +430,33 @@ export function dependicusCli(config: DependicusCliConfig): {
 
                         const { effectiveConfig, resolved, jsonPath } = resolveConfig();
 
-                        // If --github-owner/--github-repo are given, wrap getGitHubIssueSpec to inject them
+                        // Build the final spec function: merge → CLI flag injection → validation
                         const ownerOverride = options.githubOwner as string | undefined;
                         const repoOverride = options.githubRepo as string | undefined;
-                        const baseGetGitHubIssueSpec = resolved.getGitHubIssueSpec;
-                        const effectiveGetGitHubIssueSpec: typeof resolved.getGitHubIssueSpec =
-                            (ownerOverride || repoOverride) && baseGetGitHubIssueSpec
-                                ? (ctx, s) => {
-                                      const spec = baseGetGitHubIssueSpec(ctx, s);
-                                      if (!spec) return undefined;
-                                      return {
-                                          ...spec,
-                                          ...(ownerOverride ? { owner: ownerOverride } : {}),
-                                          ...(repoOverride ? { repo: repoOverride } : {}),
-                                      };
-                                  }
-                                : ownerOverride || repoOverride
-                                  ? () => ({
-                                        owner: ownerOverride ?? '',
-                                        repo: repoOverride ?? '',
-                                    })
-                                  : resolved.getGitHubIssueSpec;
+                        const githubMerge = resolved.getGitHubIssueSpec;
+                        const githubDiag: SpecDiagnostics = { skipped: [], summarized: false };
+                        const effectiveGetGitHubIssueSpec = githubMerge
+                            ? (ctx: GitHubVersionContext, s: FactStore) => {
+                                  const partial = githubMerge(ctx, s);
+                                  if (!partial) return undefined;
+                                  const patched = {
+                                      ...partial,
+                                      ...(ownerOverride ? { owner: ownerOverride } : {}),
+                                      ...(repoOverride ? { repo: repoOverride } : {}),
+                                  };
+                                  return validateGitHubIssueSpec(patched, ctx.name, githubDiag);
+                              }
+                            : ownerOverride || repoOverride
+                              ? (ctx: GitHubVersionContext) =>
+                                    validateGitHubIssueSpec(
+                                        {
+                                            owner: ownerOverride ?? '',
+                                            repo: repoOverride ?? '',
+                                        },
+                                        ctx.name,
+                                        githubDiag,
+                                    )
+                              : undefined;
 
                         const dependicus = await createDependicusInstance(
                             effectiveConfig,

--- a/packages/dependicus/src/compliance.test.ts
+++ b/packages/dependicus/src/compliance.test.ts
@@ -92,7 +92,9 @@ describe('compliance columns', () => {
 
         const version = makeDependencyVersion();
         const complianceCol = plugin.columns!.find((c) => c.key === 'compliance')!;
-        expect(complianceCol.getValue('test-pkg', version, store)).toBe('Non-Compliant');
+        expect(complianceCol.getValue({ name: 'test-pkg', version, store, ecosystem: 'npm' })).toBe(
+            'Non-Compliant',
+        );
     });
 
     it('returns compliant for dependencies within threshold', () => {
@@ -107,7 +109,9 @@ describe('compliance columns', () => {
 
         const version = makeDependencyVersion();
         const complianceCol = plugin.columns!.find((c) => c.key === 'compliance')!;
-        expect(complianceCol.getValue('test-pkg', version, store)).toBe('Compliant');
+        expect(complianceCol.getValue({ name: 'test-pkg', version, store, ecosystem: 'npm' })).toBe(
+            'Compliant',
+        );
     });
 
     it('returns not-applicable when no policy set', () => {
@@ -117,7 +121,9 @@ describe('compliance columns', () => {
 
         const version = makeDependencyVersion();
         const complianceCol = plugin.columns!.find((c) => c.key === 'compliance')!;
-        expect(complianceCol.getValue('test-pkg', version, store)).toBe('N/A');
+        expect(complianceCol.getValue({ name: 'test-pkg', version, store, ecosystem: 'npm' })).toBe(
+            'N/A',
+        );
     });
 
     it('returns detail text for non-compliant dependencies', () => {
@@ -136,7 +142,7 @@ describe('compliance columns', () => {
 
         const version = makeDependencyVersion();
         const detailCol = plugin.columns!.find((c) => c.key === 'complianceDetail')!;
-        const detail = detailCol.getValue('test-pkg', version, store);
+        const detail = detailCol.getValue({ name: 'test-pkg', version, store, ecosystem: 'npm' });
         expect(detail).toContain('Major update');
         expect(detail).toContain('overdue');
     });

--- a/packages/dependicus/src/compliance.ts
+++ b/packages/dependicus/src/compliance.ts
@@ -435,7 +435,7 @@ export class BasicCompliancePlugin implements DependicusPlugin {
                 width: 140,
                 filter: 'list',
                 filterValues: STATUS_LABELS,
-                getValue: (name, version, store) => {
+                getValue: ({ name, version, store }) => {
                     const { status } = this.computeStatus(
                         name,
                         version.version,
@@ -444,14 +444,14 @@ export class BasicCompliancePlugin implements DependicusPlugin {
                     );
                     return STATUS_LABELS[status] ?? status;
                 },
-                getFilterValue: (name, version, store) =>
+                getFilterValue: ({ name, version, store }) =>
                     this.computeStatus(name, version.version, version.latestVersion, store).status,
             },
             {
                 key: 'complianceDetail',
                 header: 'Compliance Detail',
                 width: 200,
-                getValue: (name, version, store) =>
+                getValue: ({ name, version, store }) =>
                     formatComplianceDetail(
                         this.computeStatus(name, version.version, version.latestVersion, store),
                     ),

--- a/packages/dependicus/src/index.ts
+++ b/packages/dependicus/src/index.ts
@@ -4,6 +4,9 @@
 export type { DependicusPlugin } from './plugin';
 
 /** @group Plugins */
+export type { PluginContext } from '@dependicus/core';
+
+/** @group Plugins */
 export type { GroupingConfig } from '@dependicus/core';
 
 /** @group Plugins */
@@ -13,7 +16,7 @@ export type { GroupingDetailContext } from '@dependicus/core';
 export type { GroupingSection, GroupingStat, GroupingFlag } from '@dependicus/core';
 
 /** @group Plugins */
-export type { CustomColumn } from '@dependicus/site-builder';
+export type { CustomColumn, ColumnContext } from '@dependicus/site-builder';
 
 /** @group Plugins */
 export type { DependencyVersion } from '@dependicus/core';

--- a/packages/dependicus/src/plugin.test.ts
+++ b/packages/dependicus/src/plugin.test.ts
@@ -8,8 +8,8 @@ import type {
 import { RootFactStore } from '@dependicus/core';
 import type { VersionContext } from '@dependicus/linear';
 import type { CustomColumn } from '@dependicus/site-builder';
-import { resolvePlugins } from './plugin';
-import type { DependicusPlugin } from './plugin';
+import { resolvePlugins, validateLinearIssueSpec } from './plugin';
+import type { DependicusPlugin, SpecDiagnostics } from './plugin';
 import type { DependicusCliConfig } from './cli';
 
 const mockStore = new RootFactStore();
@@ -146,7 +146,7 @@ describe('resolvePlugins', () => {
     });
 
     describe('linear callbacks', () => {
-        it('direct config getLinearIssueSpec wins over plugin', () => {
+        it('merges config spec with plugin specs (plugin overrides scalars)', () => {
             const directFn = () => ({ teamId: 'team', group: 'direct-group' });
             const pluginFn = () => ({ teamId: 'team', group: 'plugin-group' });
 
@@ -160,7 +160,7 @@ describe('resolvePlugins', () => {
             const result = resolvePlugins([plugin], config);
             expect(result.getLinearIssueSpec?.({} as VersionContext, mockStore)).toEqual({
                 teamId: 'team',
-                group: 'direct-group',
+                group: 'plugin-group',
             });
         });
 
@@ -231,13 +231,16 @@ describe('resolvePlugins', () => {
             ]);
         });
 
-        it('returns undefined when merged result is missing teamId', () => {
+        it('returns unvalidated partial when merged result is missing teamId', () => {
             const fn1 = () => ({ policy: { type: 'fyi' as const } });
 
             const p1: DependicusPlugin = { name: 'p1', getLinearIssueSpec: fn1 };
 
             const result = resolvePlugins([p1], baseConfig());
-            expect(result.getLinearIssueSpec?.({} as VersionContext, mockStore)).toBeUndefined();
+            // Merge returns the partial without validation
+            expect(result.getLinearIssueSpec?.({} as VersionContext, mockStore)).toEqual({
+                policy: { type: 'fyi' },
+            });
         });
 
         it('single plugin returning full spec works as before', () => {
@@ -276,5 +279,28 @@ describe('resolvePlugins', () => {
             expect(result.columns).toEqual([col1, col2]);
             expect(result.groupings).toEqual([grp1, grp2]);
         });
+    });
+});
+
+describe('validateLinearIssueSpec', () => {
+    it('returns validated spec when all required fields are present', () => {
+        const diag: SpecDiagnostics = { skipped: [], summarized: false };
+        const result = validateLinearIssueSpec({ teamId: 'team-a' }, 'react', diag);
+        expect(result).toEqual({ teamId: 'team-a' });
+        expect(diag.skipped).toEqual([]);
+    });
+
+    it('returns undefined and records diagnostic when teamId is missing', () => {
+        const diag: SpecDiagnostics = { skipped: [], summarized: false };
+        const result = validateLinearIssueSpec({ policy: { type: 'fyi' } }, 'react', diag);
+        expect(result).toBeUndefined();
+        expect(diag.skipped).toEqual(['react']);
+    });
+
+    it('returns undefined for undefined input', () => {
+        const diag: SpecDiagnostics = { skipped: [], summarized: false };
+        const result = validateLinearIssueSpec(undefined, 'react', diag);
+        expect(result).toBeUndefined();
+        expect(diag.skipped).toEqual([]);
     });
 });

--- a/packages/dependicus/src/plugin.ts
+++ b/packages/dependicus/src/plugin.ts
@@ -5,6 +5,7 @@ import type {
     GroupingSection,
     FactStore,
     UsedByGroupKeyFn,
+    PluginContext,
 } from '@dependicus/core';
 import type { CustomColumn } from '@dependicus/site-builder';
 import type { VersionContext, LinearIssueSpec } from '@dependicus/linear';
@@ -14,9 +15,15 @@ import type { VersionContext as GitHubVersionContext } from '@dependicus/github-
 import { gitHubIssueSpecSchema } from '@dependicus/github-issues';
 import type { DependicusCliConfig } from './cli';
 
+// Re-export for consumers
+export type { PluginContext };
+
 /** @group Plugins */
 export interface DependicusPlugin {
     name: string;
+
+    /** Called after services are created but before data collection. */
+    init?(ctx: PluginContext): void;
 
     sources?: DataSource[];
     columns?: CustomColumn[];
@@ -42,39 +49,31 @@ export interface ResolvedPlugins {
     columns: CustomColumn[];
     getUsedByGroupKey?: UsedByGroupKeyFn;
     getSections?: (ctx: GroupingDetailContext) => GroupingSection[];
-    getLinearIssueSpec?: (context: VersionContext, store: FactStore) => LinearIssueSpec | undefined;
+    /** Returns unvalidated merged partials — call validateLinearIssueSpec before use. */
+    getLinearIssueSpec?: (
+        context: VersionContext,
+        store: FactStore,
+    ) => Partial<LinearIssueSpec> | undefined;
+    /** Returns unvalidated merged partials — call validateGitHubIssueSpec before use. */
     getGitHubIssueSpec?: (
         context: GitHubVersionContext,
         store: FactStore,
-    ) => GitHubIssueSpec | undefined;
+    ) => Partial<GitHubIssueSpec> | undefined;
 }
+
+// ── Merge (no validation) ───────────────────────────────────────────
 
 function mergeLinearIssueSpecs(
     fns: Array<(ctx: VersionContext, store: FactStore) => Partial<LinearIssueSpec> | undefined>,
-): ((ctx: VersionContext, store: FactStore) => LinearIssueSpec | undefined) | undefined {
+): ((ctx: VersionContext, store: FactStore) => Partial<LinearIssueSpec> | undefined) | undefined {
     if (fns.length === 0) return undefined;
-    const skipped: string[] = [];
-    let summarized = false;
     return (ctx, store) => {
         const partials = fns.map((fn) => fn(ctx, store)).filter((p) => p !== undefined);
         if (partials.length === 0) return undefined;
         const allSections = partials.flatMap((p) => p.descriptionSections ?? []);
-        const merged = Object.assign({}, ...partials);
+        const merged = Object.assign({}, ...partials) as Partial<LinearIssueSpec>;
         if (allSections.length > 0) merged.descriptionSections = allSections;
-        const result = linearIssueSpecSchema.safeParse(merged);
-        if (!result.success) {
-            skipped.push(ctx.name);
-            if (!summarized) {
-                summarized = true;
-                queueMicrotask(() => {
-                    process.stderr.write(
-                        `Skipped ${skipped.length} dependencies with incomplete Linear issue specs: ${skipped.join(', ')}\n`,
-                    );
-                });
-            }
-            return undefined;
-        }
-        return result.data;
+        return merged;
     };
 }
 
@@ -82,32 +81,72 @@ function mergeGitHubIssueSpecs(
     fns: Array<
         (ctx: GitHubVersionContext, store: FactStore) => Partial<GitHubIssueSpec> | undefined
     >,
-): ((ctx: GitHubVersionContext, store: FactStore) => GitHubIssueSpec | undefined) | undefined {
+):
+    | ((ctx: GitHubVersionContext, store: FactStore) => Partial<GitHubIssueSpec> | undefined)
+    | undefined {
     if (fns.length === 0) return undefined;
-    const skipped: string[] = [];
-    let summarized = false;
     return (ctx, store) => {
         const partials = fns.map((fn) => fn(ctx, store)).filter((p) => p !== undefined);
         if (partials.length === 0) return undefined;
         const allSections = partials.flatMap((p) => p.descriptionSections ?? []);
-        const merged = Object.assign({}, ...partials);
+        const merged = Object.assign({}, ...partials) as Partial<GitHubIssueSpec>;
         if (allSections.length > 0) merged.descriptionSections = allSections;
-        const result = gitHubIssueSpecSchema.safeParse(merged);
-        if (!result.success) {
-            skipped.push(ctx.name);
-            if (!summarized) {
-                summarized = true;
-                queueMicrotask(() => {
-                    process.stderr.write(
-                        `Skipped ${skipped.length} dependencies with incomplete GitHub issue specs: ${skipped.join(', ')}\n`,
-                    );
-                });
-            }
-            return undefined;
-        }
-        return result.data;
+        return merged;
     };
 }
+
+// ── Validation (called by CLI after flag injection) ─────────────────
+
+export interface SpecDiagnostics {
+    skipped: string[];
+    summarized: boolean;
+}
+
+export function validateLinearIssueSpec(
+    partial: Partial<LinearIssueSpec> | undefined,
+    depName: string,
+    diag: SpecDiagnostics,
+): LinearIssueSpec | undefined {
+    if (!partial) return undefined;
+    const result = linearIssueSpecSchema.safeParse(partial);
+    if (!result.success) {
+        diag.skipped.push(depName);
+        if (!diag.summarized) {
+            diag.summarized = true;
+            queueMicrotask(() => {
+                process.stderr.write(
+                    `Skipped ${diag.skipped.length} dependencies with incomplete Linear issue specs: ${diag.skipped.join(', ')}\n`,
+                );
+            });
+        }
+        return undefined;
+    }
+    return result.data;
+}
+
+export function validateGitHubIssueSpec(
+    partial: Partial<GitHubIssueSpec> | undefined,
+    depName: string,
+    diag: SpecDiagnostics,
+): GitHubIssueSpec | undefined {
+    if (!partial) return undefined;
+    const result = gitHubIssueSpecSchema.safeParse(partial);
+    if (!result.success) {
+        diag.skipped.push(depName);
+        if (!diag.summarized) {
+            diag.summarized = true;
+            queueMicrotask(() => {
+                process.stderr.write(
+                    `Skipped ${diag.skipped.length} dependencies with incomplete GitHub issue specs: ${diag.skipped.join(', ')}\n`,
+                );
+            });
+        }
+        return undefined;
+    }
+    return result.data;
+}
+
+// ── Plugin resolution ───────────────────────────────────────────────
 
 export function resolvePlugins(
     plugins: DependicusPlugin[],
@@ -128,35 +167,31 @@ export function resolvePlugins(
             ? (ctx: GroupingDetailContext): GroupingSection[] => sectionFns.flatMap((fn) => fn(ctx))
             : undefined;
 
-    // Merge plugin issue specs; direct config override bypasses merging
-    const pluginLinearIssueSpecFns = plugins
-        .map((p) => p.getLinearIssueSpec)
-        .filter(
-            (
-                fn,
-            ): fn is (
-                context: VersionContext,
-                store: FactStore,
-            ) => Partial<LinearIssueSpec> | undefined => fn !== undefined,
-        );
+    // Merge Linear issue specs: config spec (if any) + plugin specs
+    const linearIssueSpecFns: Array<
+        (ctx: VersionContext, store: FactStore) => Partial<LinearIssueSpec> | undefined
+    > = [];
+    if (config.linear?.getLinearIssueSpec) {
+        const configFn = config.linear.getLinearIssueSpec;
+        linearIssueSpecFns.push((ctx, store) => configFn(ctx, store));
+    }
+    for (const p of plugins) {
+        if (p.getLinearIssueSpec) linearIssueSpecFns.push(p.getLinearIssueSpec);
+    }
+    const getLinearIssueSpec = mergeLinearIssueSpecs(linearIssueSpecFns);
 
-    const getLinearIssueSpec =
-        config.linear?.getLinearIssueSpec ?? mergeLinearIssueSpecs(pluginLinearIssueSpecFns);
-
-    // Merge plugin GitHub issue specs; direct config override bypasses merging
-    const pluginGitHubIssueSpecFns = plugins
-        .map((p) => p.getGitHubIssueSpec)
-        .filter(
-            (
-                fn,
-            ): fn is (
-                context: GitHubVersionContext,
-                store: FactStore,
-            ) => Partial<GitHubIssueSpec> | undefined => fn !== undefined,
-        );
-
-    const getGitHubIssueSpec =
-        config.github?.getGitHubIssueSpec ?? mergeGitHubIssueSpecs(pluginGitHubIssueSpecFns);
+    // Merge GitHub issue specs: config spec (if any) + plugin specs
+    const gitHubIssueSpecFns: Array<
+        (ctx: GitHubVersionContext, store: FactStore) => Partial<GitHubIssueSpec> | undefined
+    > = [];
+    if (config.github?.getGitHubIssueSpec) {
+        const configFn = config.github.getGitHubIssueSpec;
+        gitHubIssueSpecFns.push((ctx, store) => configFn(ctx, store));
+    }
+    for (const p of plugins) {
+        if (p.getGitHubIssueSpec) gitHubIssueSpecFns.push(p.getGitHubIssueSpec);
+    }
+    const getGitHubIssueSpec = mergeGitHubIssueSpecs(gitHubIssueSpecFns);
 
     return {
         sources,

--- a/packages/github-issues/src/issueDescriptions.test.ts
+++ b/packages/github-issues/src/issueDescriptions.test.ts
@@ -177,28 +177,28 @@ describe('buildIssueDescription', () => {
     it('includes package description as blockquote', () => {
         const dep = makeDependency();
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('> A test package');
     });
 
     it('includes summary with version info', () => {
         const dep = makeDependency();
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('## Summary');
         expect(result).toContain('**Current version:** `1.0.0`');
         expect(result).toContain('**Target version:** `1.1.0`');
@@ -209,43 +209,43 @@ describe('buildIssueDescription', () => {
     it('includes due date in body when provided', () => {
         const dep = makeDependency();
         const store = makeStore(dep);
-        const result = buildIssueDescription(
+        const result = buildIssueDescription({
             dep,
             store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-            '2025-06-01',
-        );
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+            dueDate: '2025-06-01',
+        });
         expect(result).toContain('**Due date:** 2025-06-01');
     });
 
     it('omits due date when not provided', () => {
         const dep = makeDependency();
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).not.toContain('Due date');
     });
 
     it('includes upgrade path', () => {
         const dep = makeDependency();
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('## Upgrade Path');
         expect(result).toContain('**2.0.0** (latest)');
     });
@@ -256,14 +256,14 @@ describe('buildIssueDescription', () => {
             homepage: 'https://example.com',
             repositoryUrl: 'https://github.com/example/test',
         });
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('[Dependicus Detail Page]');
         expect(result).toContain('[Registry]');
         expect(result).toContain('[Homepage](https://example.com)');
@@ -272,14 +272,14 @@ describe('buildIssueDescription', () => {
     it('includes patch warning when patched', () => {
         const dep = makeDependency();
         const store = makeStore(dep, { isPatched: true });
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('Patch Applied');
     });
 
@@ -288,14 +288,14 @@ describe('buildIssueDescription', () => {
             descriptionSections: [{ title: 'Policy Info', body: 'Must comply within 90 days.' }],
         });
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('## Policy Info');
         expect(result).toContain('Must comply within 90 days.');
     });
@@ -303,42 +303,42 @@ describe('buildIssueDescription', () => {
     it('includes footer about auto-creation', () => {
         const dep = makeDependency();
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('automatically created by Dependicus');
     });
 
     it('quotes scoped package names in catalog YAML', () => {
         const dep = makeDependency({ name: '@scope/my-pkg' });
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain("'@scope/my-pkg': 2.0.0");
     });
 
     it('does not quote unscoped package names in catalog YAML', () => {
         const dep = makeDependency({ name: 'test-pkg' });
         const store = makeStore(dep);
-        const result = buildIssueDescription(
-            dep,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: dep,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('test-pkg: 2.0.0');
         expect(result).not.toContain("'test-pkg'");
     });
@@ -359,12 +359,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('**react-group** dependency group');
         expect(result).toContain('**Dependencies:** 2');
         expect(result).toContain('**Worst update type:** major');
@@ -381,13 +381,13 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-            '2025-06-01',
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+            dueDate: '2025-06-01',
+        });
         expect(result).toContain('**Due date:** 2025-06-01');
     });
 
@@ -402,12 +402,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('Tracked for awareness only');
     });
 
@@ -422,12 +422,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('```yaml');
         expect(result).toContain('react: 2.0.0');
     });
@@ -446,12 +446,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain("'@scope/pkg-a': 2.0.0");
         expect(result).toContain('pkg-b: 2.0.0');
         expect(result).not.toContain("'pkg-b'");

--- a/packages/github-issues/src/issueDescriptions.ts
+++ b/packages/github-issues/src/issueDescriptions.ts
@@ -32,18 +32,28 @@ const issueDescriptionTemplate = hbs.compile(issueDescriptionHbs);
 const groupDescriptionTemplate = hbs.compile(groupDescriptionHbs);
 const newVersionsCommentTemplate = hbs.compile(newVersionsCommentHbs);
 
+export interface IssueDescriptionParams {
+    dep: OutdatedDependency;
+    store: FactStore;
+    minVersion: string;
+    effectiveLatestVersion: string;
+    getDetailUrl: DetailUrlFn;
+    providerInfo: ProviderInfo;
+    dueDate?: string;
+}
+
 /**
  * Build the description for a single-dependency GitHub issue.
  */
-export function buildIssueDescription(
-    dep: OutdatedDependency,
-    store: FactStore,
-    minVersion: string,
-    effectiveLatestVersion: string,
-    getDetailUrl: DetailUrlFn,
-    providerInfo: ProviderInfo,
-    dueDate?: string,
-): string {
+export function buildIssueDescription({
+    dep,
+    store,
+    minVersion,
+    effectiveLatestVersion,
+    getDetailUrl,
+    providerInfo,
+    dueDate,
+}: IssueDescriptionParams): string {
     const { name, ecosystem, versions, worstCompliance } = dep;
     const version = versions[0];
     if (!version) {
@@ -166,13 +176,21 @@ export function buildIssueDescription(
 /**
  * Build the description for a grouped GitHub issue.
  */
-export function buildGroupIssueDescription(
-    group: OutdatedGroup,
-    store: FactStore,
-    getDetailUrl: DetailUrlFn,
-    providerInfoMap: Map<string, ProviderInfo>,
-    dueDate?: string,
-): string {
+export interface GroupDescriptionParams {
+    group: OutdatedGroup;
+    store: FactStore;
+    getDetailUrl: DetailUrlFn;
+    providerInfoMap: Map<string, ProviderInfo>;
+    dueDate?: string;
+}
+
+export function buildGroupIssueDescription({
+    group,
+    store,
+    getDetailUrl,
+    providerInfoMap,
+    dueDate,
+}: GroupDescriptionParams): string {
     const { groupName, dependencies, worstCompliance } = group;
 
     const notificationsOnly = group.policy.type === 'fyi';

--- a/packages/github-issues/src/issueReconciler.ts
+++ b/packages/github-issues/src/issueReconciler.ts
@@ -516,15 +516,15 @@ export async function reconcileGitHubIssues(
         if (!providerInfo) {
             throw new Error(`No provider info for ecosystem "${dep.ecosystem}"`);
         }
-        const description = buildIssueDescription(
+        const description = buildIssueDescription({
             dep,
-            scopedStore,
+            store: scopedStore,
             minVersion,
             effectiveLatestVersion,
             getDetailUrl,
             providerInfo,
-            dueDateStr,
-        );
+            dueDate: dueDateStr,
+        });
 
         if (existingIssue) {
             // Check if new versions were released since last update
@@ -702,13 +702,13 @@ export async function reconcileGitHubIssues(
         if (dueDateStr && !groupNotificationsOnly) {
             title = `${title} (due ${dueDateStr})`;
         }
-        const description = buildGroupIssueDescription(
+        const description = buildGroupIssueDescription({
             group,
             store,
             getDetailUrl,
-            config.providerInfoMap,
-            dueDateStr,
-        );
+            providerInfoMap: config.providerInfoMap,
+            dueDate: dueDateStr,
+        });
 
         if (existingIssue) {
             // For fyi groups with rate limits, check if we should skip

--- a/packages/linear/src/issueDescriptions.test.ts
+++ b/packages/linear/src/issueDescriptions.test.ts
@@ -178,14 +178,14 @@ describe('buildIssueDescription', () => {
     it('includes package description as blockquote', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('> A test package');
     });
 
@@ -201,28 +201,28 @@ describe('buildIssueDescription', () => {
                 FactKeys.DESCRIPTION,
                 undefined as unknown as string,
             );
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).not.toContain('> ');
     });
 
     it('includes summary with version info', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('## Summary');
         expect(result).toContain('**Current version:** `1.0.0`');
         expect(result).toContain('**Target version:** `1.1.0`');
@@ -236,14 +236,14 @@ describe('buildIssueDescription', () => {
     it('hides latest version when target equals latest', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '2.0.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '2.0.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).not.toContain('**Latest version:**');
     });
 
@@ -257,14 +257,14 @@ describe('buildIssueDescription', () => {
         const store = makeStore(pkg);
         // Also populate facts for the second version
         store.setVersionFact(pkg.name, '0.9.0', FactKeys.VERSIONS_BETWEEN, defaultVersionsBetween);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('**Current versions in monorepo:**');
         expect(result).toContain('`1.0.0`');
         expect(result).toContain('`0.9.0`');
@@ -273,28 +273,28 @@ describe('buildIssueDescription', () => {
     it('shows display label', () => {
         const pkg = makeDependency({ ownerLabel: 'Web App (Frontend)' });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('- Web App (Frontend)');
     });
 
     it('shows catalog How to Update', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('managed in the catalog');
         expect(result).toContain('  test-pkg: 2.0.0');
     });
@@ -304,14 +304,14 @@ describe('buildIssueDescription', () => {
             versions: [makeVersion({ inCatalog: false, usedBy: ['@app/web'] })],
         });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('NOT in the catalog');
         expect(result).toContain('`@app/web`');
     });
@@ -326,14 +326,14 @@ describe('buildIssueDescription', () => {
             ],
         });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('used by 2 packages');
         expect(result).toContain('Consider adding it to the catalog');
     });
@@ -341,28 +341,28 @@ describe('buildIssueDescription', () => {
     it('quotes scoped package names in catalog YAML', () => {
         const pkg = makeDependency({ name: '@scope/my-pkg' });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain("'@scope/my-pkg': 2.0.0");
     });
 
     it('does not quote unscoped package names in catalog YAML', () => {
         const pkg = makeDependency({ name: 'test-pkg' });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('test-pkg: 2.0.0');
         expect(result).not.toContain("'test-pkg'");
     });
@@ -370,14 +370,14 @@ describe('buildIssueDescription', () => {
     it('includes patch warning when patched', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg, { isPatched: true });
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('Patch Applied');
     });
 
@@ -386,14 +386,14 @@ describe('buildIssueDescription', () => {
             descriptionSections: [{ title: 'Policy Info', body: 'Must comply within 90 days.' }],
         });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('## Policy Info');
         expect(result).toContain('Must comply within 90 days.');
     });
@@ -401,14 +401,14 @@ describe('buildIssueDescription', () => {
     it('includes major version available note', () => {
         const pkg = makeDependency({ availableMajorVersion: '3.0.0' });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('Major Version Available');
         expect(result).toContain('`3.0.0`');
     });
@@ -416,14 +416,14 @@ describe('buildIssueDescription', () => {
     it('includes upgrade path with version list', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('## Upgrade Path');
         expect(result).toContain('**2.0.0** (latest)');
         expect(result).toContain('1.1.0');
@@ -444,14 +444,14 @@ describe('buildIssueDescription', () => {
                 releases: [],
             },
         });
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('[Dependicus Detail Page]');
         expect(result).toContain('[Registry]');
         expect(result).toContain('[Dependency Graph]');
@@ -464,14 +464,14 @@ describe('buildIssueDescription', () => {
     it('includes deprecated transitive deps warning', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg, { deprecatedTransitiveDeps: ['old-dep', 'ancient-lib'] });
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('Deprecated Transitive Dependencies');
         expect(result).toContain('`old-dep`');
         expect(result).toContain('`ancient-lib`');
@@ -480,14 +480,14 @@ describe('buildIssueDescription', () => {
     it('includes AI agent instructions and footer', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('PR title should be');
         expect(result).toContain('automatically created by Dependicus');
     });
@@ -495,14 +495,14 @@ describe('buildIssueDescription', () => {
     it('handles scoped package names in detail URL', () => {
         const pkg = makeDependency({ name: '@scope/my-pkg' });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         // Scoped names should have @ removed and / replaced with -
         expect(result).toContain('scope-my-pkg@1.0.0.html');
     });
@@ -520,14 +520,14 @@ describe('buildIssueDescription', () => {
 
         const pkg = makeDependency();
         const store = makeStore(pkg, { versionsBetween: manyVersions });
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '1.20.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '1.20.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('... and 5 more versions');
     });
 
@@ -537,14 +537,14 @@ describe('buildIssueDescription', () => {
             versions: [makeVersion({ inCatalog: false, usedBy: manyUsedBy })],
         });
         const store = makeStore(pkg);
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('... and 5 more');
     });
 
@@ -553,14 +553,14 @@ describe('buildIssueDescription', () => {
         const store = makeStore(pkg, {
             compareUrl: 'https://github.com/example/test/compare/v1.0.0...v2.0.0',
         });
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('[View full diff on GitHub]');
         expect(result).toContain('compare/v1.0.0...v2.0.0');
     });
@@ -568,14 +568,14 @@ describe('buildIssueDescription', () => {
     it('handles empty versionsBetween', () => {
         const pkg = makeDependency();
         const store = makeStore(pkg, { versionsBetween: [] });
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '2.0.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '2.0.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).not.toContain('## Upgrade Path');
     });
 
@@ -596,14 +596,14 @@ describe('buildIssueDescription', () => {
                 ],
             },
         });
-        const result = buildIssueDescription(
-            pkg,
-            store,
-            '1.1.0',
-            '2.0.0',
-            testGetDetailUrl,
-            npmProviderInfo,
-        );
+        const result = buildIssueDescription({
+            dep: pkg,
+            store: store,
+            minVersion: '1.1.0',
+            effectiveLatestVersion: '2.0.0',
+            getDetailUrl: testGetDetailUrl,
+            providerInfo: npmProviderInfo,
+        });
         expect(result).toContain('[GitHub Release]');
     });
 });
@@ -622,12 +622,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('**react-group** dependency group');
         expect(result).toContain('**Group:** react-group');
         expect(result).toContain('**Dependencies:** 2');
@@ -650,12 +650,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('Tracked for awareness only');
         expect(result).not.toContain('Worst update type');
     });
@@ -673,12 +673,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('### @scope/pkg-a');
         expect(result).toContain('### pkg-b');
         expect(result).toContain('[Dependicus Detail]');
@@ -694,12 +694,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('```yaml');
         expect(result).toContain('catalog:');
         expect(result).toContain('react: 2.0.0');
@@ -718,12 +718,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain("'@scope/pkg-a': 2.0.0");
         expect(result).toContain('pkg-b: 2.0.0');
         expect(result).not.toContain("'pkg-b'");
@@ -739,12 +739,12 @@ describe('buildGroupIssueDescription', () => {
         };
 
         const store = makeGroupStore(group);
-        const result = buildGroupIssueDescription(
-            group,
-            store,
-            testGetDetailUrl,
-            npmProviderInfoMap,
-        );
+        const result = buildGroupIssueDescription({
+            group: group,
+            store: store,
+            getDetailUrl: testGetDetailUrl,
+            providerInfoMap: npmProviderInfoMap,
+        });
         expect(result).toContain('PR title should be');
         expect(result).toContain('automatically created by Dependicus');
     });

--- a/packages/linear/src/issueDescriptions.ts
+++ b/packages/linear/src/issueDescriptions.ts
@@ -32,17 +32,26 @@ const issueDescriptionTemplate = hbs.compile(issueDescriptionHbs);
 const groupDescriptionTemplate = hbs.compile(groupDescriptionHbs);
 const newVersionsCommentTemplate = hbs.compile(newVersionsCommentHbs);
 
+export interface IssueDescriptionParams {
+    dep: OutdatedDependency;
+    store: FactStore;
+    minVersion: string;
+    effectiveLatestVersion: string;
+    getDetailUrl: DetailUrlFn;
+    providerInfo: ProviderInfo;
+}
+
 /**
  * Build the description for a single-dependency Linear issue.
  */
-export function buildIssueDescription(
-    dep: OutdatedDependency,
-    store: FactStore,
-    minVersion: string,
-    effectiveLatestVersion: string,
-    getDetailUrl: DetailUrlFn,
-    providerInfo: ProviderInfo,
-): string {
+export function buildIssueDescription({
+    dep,
+    store,
+    minVersion,
+    effectiveLatestVersion,
+    getDetailUrl,
+    providerInfo,
+}: IssueDescriptionParams): string {
     const { name, ecosystem, versions, worstCompliance } = dep;
     const version = versions[0];
     if (!version) {
@@ -161,15 +170,22 @@ export function buildIssueDescription(
     return issueDescriptionTemplate(context).trim();
 }
 
+export interface GroupDescriptionParams {
+    group: OutdatedGroup;
+    store: FactStore;
+    getDetailUrl: DetailUrlFn;
+    providerInfoMap: Map<string, ProviderInfo>;
+}
+
 /**
  * Build the description for a grouped Linear issue.
  */
-export function buildGroupIssueDescription(
-    group: OutdatedGroup,
-    store: FactStore,
-    getDetailUrl: DetailUrlFn,
-    providerInfoMap: Map<string, ProviderInfo>,
-): string {
+export function buildGroupIssueDescription({
+    group,
+    store,
+    getDetailUrl,
+    providerInfoMap,
+}: GroupDescriptionParams): string {
     const { groupName, dependencies, worstCompliance } = group;
 
     const notificationsOnly = group.policy.type === 'fyi';

--- a/packages/linear/src/issueReconciler.ts
+++ b/packages/linear/src/issueReconciler.ts
@@ -511,14 +511,14 @@ export async function reconcileIssues(
         if (!providerInfo) {
             throw new Error(`No provider info for ecosystem "${dep.ecosystem}"`);
         }
-        const description = buildIssueDescription(
+        const description = buildIssueDescription({
             dep,
-            scopedStore,
+            store: scopedStore,
             minVersion,
             effectiveLatestVersion,
             getDetailUrl,
             providerInfo,
-        );
+        });
 
         if (existingIssue) {
             // Issue exists - check if it's in a state where we should skip updating
@@ -700,12 +700,12 @@ export async function reconcileIssues(
         const title = buildGroupTicketTitle(group.groupName, group.dependencies.length, {
             notificationsOnly: groupNotificationsOnly,
         });
-        const description = buildGroupIssueDescription(
+        const description = buildGroupIssueDescription({
             group,
             store,
             getDetailUrl,
-            config.providerInfoMap,
-        );
+            providerInfoMap: config.providerInfoMap,
+        });
 
         if (existingIssue) {
             const issueStateName = existingIssue.state.name?.toLowerCase();

--- a/packages/site-builder/src/index.ts
+++ b/packages/site-builder/src/index.ts
@@ -1,5 +1,6 @@
 export { HtmlWriter } from './services/HtmlWriter';
 export type { HtmlWriterOptions, CustomColumn } from './services/HtmlWriter';
+export type { ColumnContext } from '@dependicus/core';
 export { TemplateService } from './services/TemplateService';
 export { createDependicus } from './dependicus';
 export type { DependicusConfig, DependicusInstance, CollectResult } from './dependicus';

--- a/packages/site-builder/src/services/HtmlWriter.test.ts
+++ b/packages/site-builder/src/services/HtmlWriter.test.ts
@@ -267,7 +267,7 @@ describe('HtmlWriter', () => {
                     {
                         key: 'surface',
                         header: 'Surface',
-                        getValue: (pkg, _ver, s) => {
+                        getValue: ({ name: pkg, store: s }) => {
                             const meta = s.getDependencyFact<{ surfaceId: string }>(
                                 pkg,
                                 'testMeta',
@@ -278,7 +278,7 @@ describe('HtmlWriter', () => {
                     {
                         key: 'team',
                         header: 'Team',
-                        getValue: (pkg, _ver, s) => {
+                        getValue: ({ name: pkg, store: s }) => {
                             const meta = s.getDependencyFact<{ teamName: string }>(pkg, 'testMeta');
                             return meta?.teamName ?? '';
                         },
@@ -303,7 +303,7 @@ describe('HtmlWriter', () => {
                     {
                         key: 'surface',
                         header: 'Surface',
-                        getValue: (pkg, _ver, s) => {
+                        getValue: ({ name: pkg, store: s }) => {
                             const meta = s.getDependencyFact<{ surfaceId: string }>(
                                 pkg,
                                 'testMeta',
@@ -752,7 +752,7 @@ describe('HtmlWriter', () => {
                     {
                         key: 'surface',
                         header: 'Surface',
-                        getValue: (pkg, _ver, s) => {
+                        getValue: ({ name: pkg, store: s }) => {
                             const meta = s.getDependencyFact<{ surfaceId: string }>(
                                 pkg,
                                 'testMeta',
@@ -814,7 +814,7 @@ describe('HtmlWriter', () => {
 
         it('groupDependenciesByMeta uses custom group key', async () => {
             const writer = new HtmlWriter({
-                getUsedByGroupKey: (pkg, _ver, s) => {
+                getUsedByGroupKey: ({ name: pkg, store: s }) => {
                     const meta = s.getDependencyFact<{ teamName: string }>(pkg, 'testMeta');
                     return meta?.teamName ?? 'Unknown';
                 },

--- a/packages/site-builder/src/services/HtmlWriter.ts
+++ b/packages/site-builder/src/services/HtmlWriter.ts
@@ -2,6 +2,7 @@ import DOMPurify from 'isomorphic-dompurify';
 import { marked } from 'marked';
 import { getCssContent } from '../paths';
 import type {
+    ColumnContext,
     DetailPage,
     DirectDependency,
     DependencyVersion,
@@ -59,7 +60,7 @@ export interface CustomColumn {
      */
     header: string;
     /** Extract the display value from the store. */
-    getValue: (name: string, version: DependencyVersion, store: FactStore) => string;
+    getValue: (ctx: ColumnContext) => string;
     /**
      * Column width in pixels.
      * Maps to Tabulator's [`width`](https://tabulator.info/docs/6.3/columns#width).
@@ -79,13 +80,13 @@ export interface CustomColumn {
      * Extract a tooltip string.
      * Maps to Tabulator's [`tooltip`](https://tabulator.info/docs/6.3/columns#tooltip).
      */
-    getTooltip?: (name: string, version: DependencyVersion, store: FactStore) => string;
+    getTooltip?: (ctx: ColumnContext) => string;
     /**
      * Extract a separate filter value.
      * When set, header filter matches against this value instead of the display value.
      * Implemented via a custom [`headerFilterFunc`](https://tabulator.info/docs/6.3/filter#header-function).
      */
-    getFilterValue?: (name: string, version: DependencyVersion, store: FactStore) => string;
+    getFilterValue?: (ctx: ColumnContext) => string;
 }
 
 export interface HtmlWriterOptions {
@@ -127,32 +128,26 @@ export class HtmlWriter {
      */
     private groupDependenciesByMeta(
         packages: string[],
-        name: string,
-        version: DependencyVersion,
-        store: FactStore,
+        ctx: ColumnContext,
     ): Record<string, string[]> | null {
         // eslint-disable-next-line no-null/no-null
         if (!this.getUsedByGroupKey) return null;
-        const groupKey = this.getUsedByGroupKey(name, version, store) || 'Unknown';
+        const groupKey = this.getUsedByGroupKey(ctx) || 'Unknown';
         return { [groupKey]: [...packages].sort() };
     }
 
     /**
      * Build row data for custom columns from FactStore.
      */
-    private buildCustomColumnData(
-        name: string,
-        version: DependencyVersion,
-        store: FactStore,
-    ): Record<string, string> {
+    private buildCustomColumnData(ctx: ColumnContext): Record<string, string> {
         const data: Record<string, string> = {};
         for (const col of this.columns) {
-            data[col.key] = col.getValue(name, version, store);
+            data[col.key] = col.getValue(ctx);
             if (col.getTooltip) {
-                data[`${col.key}__tooltip`] = col.getTooltip(name, version, store);
+                data[`${col.key}__tooltip`] = col.getTooltip(ctx);
             }
             if (col.getFilterValue) {
-                data[`${col.key}__filterValue`] = col.getFilterValue(name, version, store);
+                data[`${col.key}__filterValue`] = col.getFilterValue(ctx);
             }
         }
         return data;
@@ -233,7 +228,12 @@ export class HtmlWriter {
                     'Published Date': formatDate(versionInfo.publishDate) ?? '',
                     Age: getAgeDays(versionInfo.publishDate) ?? '',
                     Notes: notes,
-                    ...this.buildCustomColumnData(dep.name, versionInfo, scoped),
+                    ...this.buildCustomColumnData({
+                        name: dep.name,
+                        version: versionInfo,
+                        store: scoped,
+                        ecosystem: dep.ecosystem,
+                    }),
                     'Latest Version URL': registryPattern
                         ? resolveUrl(registryPattern, {
                               name: dep.name,
@@ -250,12 +250,12 @@ export class HtmlWriter {
                     }),
                     'Used By Count': versionInfo.usedBy.length,
                     'Used By': versionInfo.usedBy.join('; '),
-                    'Used By Grouped': this.groupDependenciesByMeta(
-                        versionInfo.usedBy,
-                        dep.name,
-                        versionInfo,
-                        scoped,
-                    ),
+                    'Used By Grouped': this.groupDependenciesByMeta(versionInfo.usedBy, {
+                        name: dep.name,
+                        version: versionInfo,
+                        store: scoped,
+                        ecosystem: dep.ecosystem,
+                    }),
                     'Deprecated Transitive Dependencies': deprecatedTransitiveDeps.join('; '),
                     'Detail Link': `${detailPrefix}details/${detailFilename}`,
                 });
@@ -505,13 +505,15 @@ export class HtmlWriter {
             unpackedSize,
         );
 
-        // Group usedBy dependencies
-        const usedByGrouped = this.groupDependenciesByMeta(
-            versionInfo.usedBy,
-            dep.name,
-            versionInfo,
+        const colCtx: ColumnContext = {
+            name: dep.name,
+            version: versionInfo,
             store,
-        );
+            ecosystem: dep.ecosystem,
+        };
+
+        // Group usedBy dependencies
+        const usedByGrouped = this.groupDependenciesByMeta(versionInfo.usedBy, colCtx);
         const usedByGroupedArray = usedByGrouped
             ? Object.keys(usedByGrouped)
                   .sort()
@@ -534,7 +536,7 @@ export class HtmlWriter {
         // Build custom metadata for display on detail page
         const customMeta: Array<{ label: string; value: string }> = [];
         for (const col of this.columns) {
-            const value = col.getValue(dep.name, versionInfo, store);
+            const value = col.getValue(colCtx);
             if (value) {
                 customMeta.push({ label: col.header, value: DOMPurify.sanitize(value) });
             }


### PR DESCRIPTION
Reworks the plugin API so enrichment plugins (like the upcoming security plugin) can compose with routing and compliance plugins without their contributions being silently dropped.

- Plugin issue specs are now merged with config-level specs instead of being overridden by them. Zod validation is deferred until after CLI flags like `--linear-team-id` are applied, fixing a bug where plugins returning partial specs (e.g. only `descriptionSections`) had their output discarded before the CLI could inject the missing `teamId`.
- Adds `init(ctx: PluginContext)` lifecycle hook so plugins can receive `CacheService` for caching API responses. Provider and plugin data sources now run in a single topological sort per ecosystem, with a new `softDependsOn` field for optional ordering across the boundary.
- Converts `CustomColumn` callbacks, `UsedByGroupKeyFn`, and `buildIssueDescription` / `buildGroupIssueDescription` (both Linear and GitHub) from positional arguments to named-field objects. Four-string-params-in-a-row is a duck that deserved to be cooked.

Breaking changes across `@dependicus/core`, `@dependicus/site-builder`, `@dependicus/linear`, and `@dependicus/github-issues`. Version bumped to 0.2.0-rc.0.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Medium risk due to breaking API changes across plugin/column/issue-description interfaces and changed source execution ordering, which can affect enrichment and issue reconciliation behavior.
> 
> **Overview**
> **Reworks the plugin API to be more composable and lifecycle-aware.** Plugins can now implement `init(ctx)` to receive shared services (notably `CacheService`) before collection starts, and plugin/provided sources are executed together per ecosystem.
> 
> Adds `softDependsOn` for `DataSource` and updates `runSources` to respect optional dependencies (ignored if absent) while still cycle-detecting when present; built-in `GitHubSource` now uses this for registry ordering.
> 
> **Breaking API updates**: introduces `ColumnContext` and changes `CustomColumn` callbacks and `UsedByGroupKeyFn` to take a single context object; Linear/GitHub `buildIssueDescription`/`buildGroupIssueDescription` now take params objects. Plugin issue spec handling is changed to *merge config + plugin partials* (concatenating `descriptionSections`), defer Zod validation until after CLI flag injection via new `validate*IssueSpec` helpers, and updates the CLI/test wiring accordingly. Version is bumped to `0.2.0-rc.0`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4b9f4159338acaaa4186159dd1e8adb5c111a89f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->