### PR TITLE
@dependicus/security

### DIFF
--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -330,6 +330,40 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@25.3.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/security:
+    dependencies:
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
+    devDependencies:
+      '@dependicus/core':
+        specifier: workspace:*
+        version: link:../core
+      '@dependicus/github-issues':
+        specifier: workspace:*
+        version: link:../github-issues
+      '@dependicus/linear':
+        specifier: workspace:*
+        version: link:../linear
+      '@dependicus/site-builder':
+        specifier: workspace:*
+        version: link:../site-builder
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
+      tsdown:
+        specifier: ^0.20.3
+        version: 0.20.3(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.3.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))
+
   packages/site-builder:
     dependencies:
       '@dependicus/core':

--- a/bun.lock
+++ b/bun.lock
@@ -175,6 +175,24 @@
         "vitest": "^4.1.0",
       },
     },
+    "packages/security": {
+      "name": "@dependicus/security",
+      "version": "0.1.0",
+      "dependencies": {
+        "semver": "^7.7.4",
+      },
+      "devDependencies": {
+        "@dependicus/core": "workspace:*",
+        "@dependicus/github-issues": "workspace:*",
+        "@dependicus/linear": "workspace:*",
+        "@dependicus/site-builder": "workspace:*",
+        "@types/node": "^25.3.0",
+        "@types/semver": "^7.7.1",
+        "tsdown": "^0.20.3",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.0",
+      },
+    },
     "packages/site-builder": {
       "name": "@dependicus/site-builder",
       "version": "0.1.0",
@@ -254,6 +272,8 @@
     "@dependicus/providers-node": ["@dependicus/providers-node@workspace:packages/providers-node"],
 
     "@dependicus/providers-python": ["@dependicus/providers-python@workspace:packages/providers-python"],
+
+    "@dependicus/security": ["@dependicus/security@workspace:packages/security"],
 
     "@dependicus/site-builder": ["@dependicus/site-builder@workspace:packages/site-builder"],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -305,6 +305,10 @@
             "resolved": "packages/providers-python",
             "link": true
         },
+        "node_modules/@dependicus/security": {
+            "resolved": "packages/security",
+            "link": true
+        },
         "node_modules/@dependicus/site-builder": {
             "resolved": "packages/site-builder",
             "link": true
@@ -5049,7 +5053,6 @@
         "packages/security": {
             "name": "@dependicus/security",
             "version": "0.1.0",
-            "extraneous": true,
             "license": "MIT",
             "dependencies": {
                 "semver": "^7.7.4"

--- a/packages/dependicus/package.json
+++ b/packages/dependicus/package.json
@@ -77,6 +77,7 @@
         "@dependicus/provider-rust": "workspace:*",
         "@dependicus/providers-node": "workspace:*",
         "@dependicus/providers-python": "workspace:*",
+        "@dependicus/security": "workspace:*",
         "@dependicus/site-builder": "workspace:*",
         "@types/node": "^25.3.0",
         "dts-bundle-generator": "^9.5.1",

--- a/packages/dependicus/src/bin.ts
+++ b/packages/dependicus/src/bin.ts
@@ -14,5 +14,8 @@ const githubRoutingPlugin: DependicusPlugin = {
 
 void dependicusCli({
     dependicusBaseUrl: '',
-    plugins: [new SecurityPlugin({ osv: true }), githubRoutingPlugin],
+    plugins: [
+        new SecurityPlugin({ osv: true, depsdev: true, githubAdvisory: true }),
+        githubRoutingPlugin,
+    ],
 }).run(process.argv);

--- a/packages/dependicus/src/bin.ts
+++ b/packages/dependicus/src/bin.ts
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 import { dependicusCli } from './cli';
+import { SecurityPlugin } from '@dependicus/security';
 import type { DependicusPlugin } from './plugin';
 
 const githubRoutingPlugin: DependicusPlugin = {
@@ -13,5 +14,5 @@ const githubRoutingPlugin: DependicusPlugin = {
 
 void dependicusCli({
     dependicusBaseUrl: '',
-    plugins: [githubRoutingPlugin],
+    plugins: [new SecurityPlugin({ osv: true }), githubRoutingPlugin],
 }).run(process.argv);

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -20,6 +20,9 @@
         "test": "vitest run",
         "typecheck": "tsc --build tsconfig.json"
     },
+    "dependencies": {
+        "@pandatix/js-cvss": "^0.4.4"
+    },
     "devDependencies": {
         "@dependicus/core": "workspace:*",
         "@dependicus/github-issues": "workspace:*",

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -20,16 +20,12 @@
         "test": "vitest run",
         "typecheck": "tsc --build tsconfig.json"
     },
-    "dependencies": {
-        "semver": "^7.7.4"
-    },
     "devDependencies": {
         "@dependicus/core": "workspace:*",
         "@dependicus/github-issues": "workspace:*",
         "@dependicus/linear": "workspace:*",
         "@dependicus/site-builder": "workspace:*",
         "@types/node": "^25.3.0",
-        "@types/semver": "^7.7.1",
         "tsdown": "^0.20.3",
         "typescript": "^5.9.3",
         "vitest": "^4.1.0"

--- a/packages/security/package.json
+++ b/packages/security/package.json
@@ -1,0 +1,37 @@
+{
+    "name": "@dependicus/security",
+    "version": "0.1.0",
+    "private": true,
+    "license": "MIT",
+    "files": [
+        "dist"
+    ],
+    "type": "module",
+    "exports": {
+        ".": {
+            "types": "./dist/index.d.mts",
+            "source": "./src/index.ts",
+            "default": "./dist/index.mjs"
+        }
+    },
+    "scripts": {
+        "build": "tsdown",
+        "clean": "rm -rf dist",
+        "test": "vitest run",
+        "typecheck": "tsc --build tsconfig.json"
+    },
+    "dependencies": {
+        "semver": "^7.7.4"
+    },
+    "devDependencies": {
+        "@dependicus/core": "workspace:*",
+        "@dependicus/github-issues": "workspace:*",
+        "@dependicus/linear": "workspace:*",
+        "@dependicus/site-builder": "workspace:*",
+        "@types/node": "^25.3.0",
+        "@types/semver": "^7.7.1",
+        "tsdown": "^0.20.3",
+        "typescript": "^5.9.3",
+        "vitest": "^4.1.0"
+    }
+}

--- a/packages/security/src/SecurityPlugin.test.ts
+++ b/packages/security/src/SecurityPlugin.test.ts
@@ -1,0 +1,131 @@
+import { describe, it, expect } from 'vitest';
+import { RootFactStore } from '@dependicus/core';
+import type { DependencyVersion } from '@dependicus/core';
+import { SecurityPlugin } from './SecurityPlugin';
+import type { SecurityFinding } from './types';
+import { SECURITY_FINDINGS_KEY } from './types';
+
+function makeVersion(overrides?: Partial<DependencyVersion>): DependencyVersion {
+    return {
+        version: '1.0.0',
+        latestVersion: '2.0.0',
+        usedBy: ['@app/web'],
+        dependencyTypes: ['prod'],
+        publishDate: '2024-01-01',
+        inCatalog: false,
+        ...overrides,
+    };
+}
+
+describe('SecurityPlugin', () => {
+    it('constructs OsvSource when osv is true', () => {
+        const plugin = new SecurityPlugin({ osv: true });
+        expect(plugin.sources).toHaveLength(1);
+        expect(plugin.sources[0]!.name).toBe('osv');
+    });
+
+    it('constructs no sources when config is empty', () => {
+        const plugin = new SecurityPlugin({});
+        expect(plugin.sources).toHaveLength(0);
+    });
+
+    it('columns return empty strings when no findings exist', () => {
+        const plugin = new SecurityPlugin({ osv: true });
+        const store = new RootFactStore();
+        const scoped = store.scoped('npm');
+        const ver = makeVersion();
+
+        const ctx = { name: 'react', version: ver, store: scoped, ecosystem: 'npm' };
+        for (const col of plugin.columns) {
+            expect(col.getValue(ctx)).toBe('');
+        }
+    });
+
+    it('columns render severity and fix when findings exist', () => {
+        const plugin = new SecurityPlugin({ osv: true });
+        const store = new RootFactStore();
+        const scoped = store.scoped('npm');
+        const ver = makeVersion();
+
+        const finding: SecurityFinding = {
+            source: 'osv',
+            sourceLabel: 'OSV',
+            severity: 'high',
+            advisoryCount: 2,
+            fixAvailable: true,
+            rationale: ['2 advisories', 'fix available in a newer version'],
+            sourceLinks: [{ label: 'GHSA-1234', url: 'https://osv.dev/vulnerability/GHSA-1234' }],
+        };
+        scoped.setVersionFact('react', '1.0.0', SECURITY_FINDINGS_KEY, [finding]);
+
+        const secCol = plugin.columns.find((c) => c.key === 'security')!;
+        const fixCol = plugin.columns.find((c) => c.key === 'securityFix')!;
+        const whyCol = plugin.columns.find((c) => c.key === 'securityWhy')!;
+
+        const ctx = { name: 'react', version: ver, store: scoped, ecosystem: 'npm' };
+        const secValue = secCol.getValue(ctx);
+        expect(secValue).toContain('High');
+        expect(secValue).toContain('<a href=');
+        expect(secValue).toContain('osv.dev');
+        expect(fixCol.getValue(ctx)).toBe('Yes');
+        const whyValue = whyCol.getValue(ctx);
+        expect(whyValue).toContain('<a href=');
+        expect(whyValue).toContain('GHSA-1234');
+        expect(whyValue).toContain('fix available');
+    });
+
+    it('getLinearIssueSpec returns description sections for findings', () => {
+        const plugin = new SecurityPlugin({ osv: true });
+        const store = new RootFactStore();
+        const scoped = store.scoped('npm');
+
+        const finding: SecurityFinding = {
+            source: 'osv',
+            sourceLabel: 'OSV',
+            severity: 'critical',
+            advisoryCount: 1,
+            fixAvailable: false,
+            rationale: ['1 advisory (CVE-2024-0001)'],
+            sourceLinks: [
+                { label: 'CVE-2024-0001', url: 'https://osv.dev/vulnerability/CVE-2024-0001' },
+            ],
+        };
+        scoped.setVersionFact('lodash', '4.17.20', SECURITY_FINDINGS_KEY, [finding]);
+
+        const spec = plugin.getLinearIssueSpec(
+            {
+                name: 'lodash',
+                ecosystem: 'npm',
+                currentVersion: '4.17.20',
+                latestVersion: '4.17.21',
+            },
+            scoped,
+        );
+
+        expect(spec).toBeDefined();
+        expect(spec!.descriptionSections).toBeDefined();
+        expect(spec!.descriptionSections!.length).toBeGreaterThanOrEqual(2);
+
+        const titles = spec!.descriptionSections!.map((s) => s.title);
+        expect(titles).toContain('Security summary');
+        expect(titles).toContain('Sources');
+    });
+
+    it('getLinearIssueSpec returns undefined when no findings', () => {
+        const plugin = new SecurityPlugin({ osv: true });
+        const store = new RootFactStore();
+        const scoped = store.scoped('npm');
+
+        const spec = plugin.getLinearIssueSpec(
+            {
+                name: 'lodash',
+                ecosystem: 'npm',
+                currentVersion: '4.17.20',
+                latestVersion: '4.17.21',
+            },
+            scoped,
+        );
+
+        expect(spec).toBeUndefined();
+    });
+});

--- a/packages/security/src/SecurityPlugin.test.ts
+++ b/packages/security/src/SecurityPlugin.test.ts
@@ -85,6 +85,17 @@ describe('SecurityPlugin', () => {
             severity: 'critical',
             advisoryCount: 1,
             fixAvailable: false,
+            advisories: [
+                {
+                    id: 'CVE-2024-0001',
+                    summary: 'Prototype pollution in lodash',
+                    severity: 'critical',
+                    cvssScore: 9.8,
+                    fixAvailable: false,
+                    url: 'https://osv.dev/vulnerability/CVE-2024-0001',
+                },
+            ],
+            advisoryIds: ['CVE-2024-0001'],
             rationale: ['1 advisory (CVE-2024-0001)'],
             sourceLinks: [
                 { label: 'CVE-2024-0001', url: 'https://osv.dev/vulnerability/CVE-2024-0001' },
@@ -108,7 +119,12 @@ describe('SecurityPlugin', () => {
 
         const titles = spec!.descriptionSections!.map((s) => s.title);
         expect(titles).toContain('Security summary');
-        expect(titles).toContain('Sources');
+        expect(titles).toContain('Advisories');
+
+        const advisorySection = spec!.descriptionSections!.find((s) => s.title === 'Advisories')!;
+        expect(advisorySection.body).toContain('CVE-2024-0001');
+        expect(advisorySection.body).toContain('Prototype pollution in lodash');
+        expect(advisorySection.body).toContain('critical');
     });
 
     it('getLinearIssueSpec returns undefined when no findings', () => {

--- a/packages/security/src/SecurityPlugin.ts
+++ b/packages/security/src/SecurityPlugin.ts
@@ -9,9 +9,11 @@ import type { ColumnContext, CustomColumn } from '@dependicus/site-builder';
 import type { VersionContext, LinearIssueSpec } from '@dependicus/linear';
 import type { GitHubIssueSpec } from '@dependicus/github-issues';
 import type { VersionContext as GitHubVersionContext } from '@dependicus/github-issues';
-import type { SecurityPluginConfig, SecurityFinding, Severity } from './types';
+import type { SecurityPluginConfig, SecurityFinding, Severity, Maintenance } from './types';
 import { SECURITY_FINDINGS_KEY, SEVERITY_ORDER } from './types';
 import { OsvSource } from './sources/OsvSource';
+import { DepsDevSource } from './sources/DepsDevSource';
+import { GitHubAdvisorySource } from './sources/GitHubAdvisorySource';
 
 // ── DependicusPlugin implementation ─────────────────────────────────
 
@@ -29,8 +31,10 @@ export class SecurityPlugin {
 
     init(ctx: PluginContext): void {
         for (const source of this.sources) {
-            if (source instanceof OsvSource) {
-                source.setCacheService(ctx.cacheService);
+            if ('setCacheService' in source && typeof source.setCacheService === 'function') {
+                (
+                    source as { setCacheService: (cs: PluginContext['cacheService']) => void }
+                ).setCacheService(ctx.cacheService);
             }
         }
     }
@@ -40,8 +44,19 @@ export class SecurityPlugin {
     private buildSources(): DataSource[] {
         const sources: DataSource[] = [];
         if (this.config.osv) {
-            const osvConfig = typeof this.config.osv === 'object' ? this.config.osv : undefined;
-            sources.push(new OsvSource(osvConfig));
+            const c = typeof this.config.osv === 'object' ? this.config.osv : undefined;
+            sources.push(new OsvSource(c));
+        }
+        if (this.config.depsdev) {
+            const c = typeof this.config.depsdev === 'object' ? this.config.depsdev : undefined;
+            sources.push(new DepsDevSource(c));
+        }
+        if (this.config.githubAdvisory) {
+            const c =
+                typeof this.config.githubAdvisory === 'object'
+                    ? this.config.githubAdvisory
+                    : undefined;
+            sources.push(new GitHubAdvisorySource(c));
         }
         return sources;
     }
@@ -52,7 +67,7 @@ export class SecurityPlugin {
         return [
             {
                 key: 'security',
-                header: 'Sec',
+                header: 'Severity',
                 width: 100,
                 filter: 'list',
                 filterValues: SEVERITY_LABELS,
@@ -63,7 +78,7 @@ export class SecurityPlugin {
                     const findings = getFindings(ctx);
                     const firstLink = findings.flatMap((f) => f.sourceLinks ?? [])[0];
                     if (firstLink) {
-                        return `<a href="${escapeAttr(firstLink.url)}" target="_blank" rel="noopener">${label}</a>`;
+                        return `<a href="${escapeAttr(firstLink.url)}">${label}</a>`;
                     }
                     return label;
                 },
@@ -74,16 +89,19 @@ export class SecurityPlugin {
                 getTooltip: (ctx) => {
                     const merged = this.mergeFindings(ctx);
                     if (!merged.severity) return '';
-                    const parts = merged.sources;
+                    const findings = getFindings(ctx);
+                    const vulnSources = [
+                        ...new Set(findings.filter((f) => f.severity).map((f) => f.sourceLabel)),
+                    ].join(', ');
                     if (merged.cvssScore !== undefined) {
-                        return `CVSS ${merged.cvssScore.toFixed(1)} (${parts})`;
+                        return `CVSS ${merged.cvssScore.toFixed(1)} (${vulnSources})`;
                     }
-                    return parts;
+                    return vulnSources;
                 },
             },
             {
                 key: 'securityFix',
-                header: 'Fix',
+                header: 'Fix Available',
                 width: 70,
                 filter: 'list',
                 filterValues: { true: 'Yes', false: 'No' },
@@ -111,10 +129,7 @@ export class SecurityPlugin {
                     const parts: string[] = [];
                     if (allLinks.length > 0) {
                         const linkedIds = allLinks
-                            .map(
-                                (l) =>
-                                    `<a href="${escapeAttr(l.url)}" target="_blank" rel="noopener">${escapeHtml(l.label)}</a>`,
-                            )
+                            .map((l) => `<a href="${escapeAttr(l.url)}">${escapeHtml(l.label)}</a>`)
                             .join(', ');
                         parts.push(linkedIds);
                     }
@@ -122,6 +137,22 @@ export class SecurityPlugin {
                         if (!r.match(/^\d+ advisor/)) parts.push(escapeHtml(r));
                     }
                     return parts.join('; ');
+                },
+            },
+            {
+                key: 'maintenance',
+                header: 'Deprecated',
+                width: 100,
+                filter: 'list',
+                filterValues: MAINTENANCE_LABELS,
+                getValue: (ctx) => {
+                    const merged = this.mergeFindings(ctx);
+                    if (merged.maintenance !== 'stale') return '';
+                    return 'Stale';
+                },
+                getFilterValue: (ctx) => {
+                    const merged = this.mergeFindings(ctx);
+                    return merged.maintenance ?? '';
                 },
             },
         ];
@@ -233,21 +264,41 @@ export class SecurityPlugin {
             summaryLines.push(`- Advisories: ${merged.advisoryCount}`);
         }
         summaryLines.push(`- Fix available: ${merged.fixAvailable ? 'yes' : 'no'}`);
+        if (merged.maintenance) {
+            summaryLines.push(`- Maintenance posture: ${merged.maintenance}`);
+        }
         sections.push({ title: 'Security summary', body: summaryLines.join('\n') });
 
-        // Why this matters
-        if (merged.rationale.length > 0) {
-            sections.push({
-                title: 'Why this matters',
-                body: merged.rationale.join('. ') + '.',
-            });
+        // Advisories (deduplicated across sources, with inline summaries)
+        const allAdvisories = findings.flatMap((f) => f.advisories ?? []);
+        if (allAdvisories.length > 0) {
+            const seen = new Set<string>();
+            const lines: string[] = [];
+            for (const a of allAdvisories) {
+                if (seen.has(a.id)) continue;
+                seen.add(a.id);
+                const parts: string[] = [`[${a.id}](${a.url})`];
+                if (a.severity) {
+                    const score = a.cvssScore !== undefined ? ` ${a.cvssScore.toFixed(1)}` : '';
+                    parts.push(`${a.severity}${score}`);
+                }
+                if (a.fixAvailable) parts.push('fix available');
+                const line = parts.join(' · ');
+                const summary = a.summary ? `: ${a.summary}` : '';
+                lines.push(`- ${line}${summary}`);
+            }
+            sections.push({ title: 'Advisories', body: lines.join('\n') });
         }
 
-        // Sources
-        const allLinks = findings.flatMap((f) => f.sourceLinks ?? []);
-        if (allLinks.length > 0) {
-            const sourceLines = allLinks.map((l) => `- [${l.label}](${l.url})`);
-            sections.push({ title: 'Sources', body: sourceLines.join('\n') });
+        // Why this matters (non-advisory rationale only)
+        const nonAdvisoryRationale = merged.rationale.filter(
+            (r) => !r.match(/^\d+ (?:advisor|GitHub advisor)/),
+        );
+        if (nonAdvisoryRationale.length > 0) {
+            sections.push({
+                title: 'Why this matters',
+                body: nonAdvisoryRationale.join('. ') + '.',
+            });
         }
 
         return sections;
@@ -264,13 +315,20 @@ const SEVERITY_LABELS: Record<string, string> = {
     critical: 'Critical',
 };
 
+const MAINTENANCE_LABELS: Record<string, string> = {
+    active: 'Active',
+    stale: 'Stale',
+    unknown: 'Unknown',
+};
+
 interface MergedFindings {
     severity: Severity | undefined;
     cvssScore: number | undefined;
     advisoryCount: number;
     fixAvailable: boolean;
+    maintenance: Maintenance | undefined;
     rationale: string[];
-    /** Comma-separated source labels (e.g. "OSV, Snyk"). */
+    /** Comma-separated source labels (e.g. "OSV, deps.dev"). */
     sources: string;
 }
 
@@ -291,15 +349,16 @@ function mergeFindingsFromArray(findings: SecurityFinding[]): MergedFindings {
             cvssScore: undefined,
             advisoryCount: 0,
             fixAvailable: false,
+            maintenance: undefined,
             rationale: [],
             sources: '',
         };
     }
 
+    // Worst severity
     const severities = findings
         .map((f) => f.severity)
         .filter((s): s is Severity => s !== undefined);
-
     let worstSeverity: Severity | undefined;
     if (severities.length > 0) {
         let worst = 0;
@@ -310,19 +369,44 @@ function mergeFindingsFromArray(findings: SecurityFinding[]): MergedFindings {
         worstSeverity = SEVERITY_ORDER[worst];
     }
 
+    // Highest CVSS score
     const scores = findings.map((f) => f.cvssScore).filter((s): s is number => s !== undefined);
     const worstScore = scores.length > 0 ? Math.max(...scores) : undefined;
 
-    const totalAdvisories = findings.reduce((sum, f) => sum + (f.advisoryCount ?? 0), 0);
+    // Deduplicated advisory count: union of advisoryIds across all sources
+    const allIds = findings.flatMap((f) => f.advisoryIds ?? []);
+    const uniqueIds = new Set(allIds);
+    const advisoryCount =
+        uniqueIds.size > 0
+            ? uniqueIds.size
+            : findings.reduce((sum, f) => sum + (f.advisoryCount ?? 0), 0);
+
     const anyFix = findings.some((f) => f.fixAvailable);
+
+    // Worst maintenance posture (stale > unknown > active)
+    const maintenanceOrder: Maintenance[] = ['active', 'unknown', 'stale'];
+    const maintenances = findings
+        .map((f) => f.maintenance)
+        .filter((m): m is Maintenance => m !== undefined);
+    let maintenance: Maintenance | undefined;
+    if (maintenances.length > 0) {
+        let worst = 0;
+        for (const m of maintenances) {
+            const idx = maintenanceOrder.indexOf(m);
+            if (idx > worst) worst = idx;
+        }
+        maintenance = maintenanceOrder[worst];
+    }
+
     const allRationale = findings.flatMap((f) => f.rationale ?? []);
     const sources = [...new Set(findings.map((f) => f.sourceLabel))].join(', ');
 
     return {
         severity: worstSeverity,
         cvssScore: worstScore,
-        advisoryCount: totalAdvisories,
+        advisoryCount,
         fixAvailable: anyFix,
+        maintenance,
         rationale: allRationale,
         sources,
     };

--- a/packages/security/src/SecurityPlugin.ts
+++ b/packages/security/src/SecurityPlugin.ts
@@ -10,7 +10,7 @@ import type { VersionContext, LinearIssueSpec } from '@dependicus/linear';
 import type { GitHubIssueSpec } from '@dependicus/github-issues';
 import type { VersionContext as GitHubVersionContext } from '@dependicus/github-issues';
 import type { SecurityPluginConfig, SecurityFinding, Severity } from './types';
-import { SECURITY_FINDINGS_KEY } from './types';
+import { SECURITY_FINDINGS_KEY, SEVERITY_ORDER } from './types';
 import { OsvSource } from './sources/OsvSource';
 
 // ── DependicusPlugin implementation ─────────────────────────────────
@@ -257,8 +257,6 @@ const SEVERITY_LABELS: Record<string, string> = {
     high: 'High',
     critical: 'Critical',
 };
-
-const SEVERITY_ORDER: Severity[] = ['none', 'low', 'medium', 'high', 'critical'];
 
 interface MergedFindings {
     severity: Severity | undefined;

--- a/packages/security/src/SecurityPlugin.ts
+++ b/packages/security/src/SecurityPlugin.ts
@@ -72,9 +72,13 @@ export class SecurityPlugin {
                     return merged.severity ?? '';
                 },
                 getTooltip: (ctx) => {
-                    const findings = getFindings(ctx);
-                    if (findings.length === 0) return '';
-                    return findings.map((f) => f.sourceLabel).join(', ');
+                    const merged = this.mergeFindings(ctx);
+                    if (!merged.severity) return '';
+                    const parts = merged.sources;
+                    if (merged.cvssScore !== undefined) {
+                        return `CVSS ${merged.cvssScore.toFixed(1)} (${parts})`;
+                    }
+                    return parts;
                 },
             },
             {
@@ -221,7 +225,9 @@ export class SecurityPlugin {
         // Security summary
         const summaryLines: string[] = [];
         if (merged.severity) {
-            summaryLines.push(`- Severity: **${merged.severity}**`);
+            const scoreSuffix =
+                merged.cvssScore !== undefined ? ` (CVSS ${merged.cvssScore.toFixed(1)})` : '';
+            summaryLines.push(`- Severity: **${merged.severity}**${scoreSuffix}`);
         }
         if (merged.advisoryCount > 0) {
             summaryLines.push(`- Advisories: ${merged.advisoryCount}`);
@@ -260,9 +266,12 @@ const SEVERITY_LABELS: Record<string, string> = {
 
 interface MergedFindings {
     severity: Severity | undefined;
+    cvssScore: number | undefined;
     advisoryCount: number;
     fixAvailable: boolean;
     rationale: string[];
+    /** Comma-separated source labels (e.g. "OSV, Snyk"). */
+    sources: string;
 }
 
 function getFindings(ctx: ColumnContext): SecurityFinding[] {
@@ -277,7 +286,14 @@ function getFindings(ctx: ColumnContext): SecurityFinding[] {
 
 function mergeFindingsFromArray(findings: SecurityFinding[]): MergedFindings {
     if (findings.length === 0) {
-        return { severity: undefined, advisoryCount: 0, fixAvailable: false, rationale: [] };
+        return {
+            severity: undefined,
+            cvssScore: undefined,
+            advisoryCount: 0,
+            fixAvailable: false,
+            rationale: [],
+            sources: '',
+        };
     }
 
     const severities = findings
@@ -294,15 +310,21 @@ function mergeFindingsFromArray(findings: SecurityFinding[]): MergedFindings {
         worstSeverity = SEVERITY_ORDER[worst];
     }
 
+    const scores = findings.map((f) => f.cvssScore).filter((s): s is number => s !== undefined);
+    const worstScore = scores.length > 0 ? Math.max(...scores) : undefined;
+
     const totalAdvisories = findings.reduce((sum, f) => sum + (f.advisoryCount ?? 0), 0);
     const anyFix = findings.some((f) => f.fixAvailable);
     const allRationale = findings.flatMap((f) => f.rationale ?? []);
+    const sources = [...new Set(findings.map((f) => f.sourceLabel))].join(', ');
 
     return {
         severity: worstSeverity,
+        cvssScore: worstScore,
         advisoryCount: totalAdvisories,
         fixAvailable: anyFix,
         rationale: allRationale,
+        sources,
     };
 }
 

--- a/packages/security/src/SecurityPlugin.ts
+++ b/packages/security/src/SecurityPlugin.ts
@@ -1,0 +1,321 @@
+import type {
+    DataSource,
+    FactStore,
+    GroupingDetailContext,
+    GroupingSection,
+    PluginContext,
+} from '@dependicus/core';
+import type { ColumnContext, CustomColumn } from '@dependicus/site-builder';
+import type { VersionContext, LinearIssueSpec } from '@dependicus/linear';
+import type { GitHubIssueSpec } from '@dependicus/github-issues';
+import type { VersionContext as GitHubVersionContext } from '@dependicus/github-issues';
+import type { SecurityPluginConfig, SecurityFinding, Severity } from './types';
+import { SECURITY_FINDINGS_KEY } from './types';
+import { OsvSource } from './sources/OsvSource';
+
+// ── DependicusPlugin implementation ─────────────────────────────────
+
+export class SecurityPlugin {
+    readonly name = 'security';
+    readonly sources: DataSource[];
+    readonly columns: CustomColumn[];
+
+    constructor(private readonly config: SecurityPluginConfig) {
+        this.sources = this.buildSources();
+        this.columns = this.buildColumns();
+    }
+
+    // ── Lifecycle ──────────────────────────────────────────────────
+
+    init(ctx: PluginContext): void {
+        for (const source of this.sources) {
+            if (source instanceof OsvSource) {
+                source.setCacheService(ctx.cacheService);
+            }
+        }
+    }
+
+    // ── Source construction ─────────────────────────────────────────
+
+    private buildSources(): DataSource[] {
+        const sources: DataSource[] = [];
+        if (this.config.osv) {
+            const osvConfig = typeof this.config.osv === 'object' ? this.config.osv : undefined;
+            sources.push(new OsvSource(osvConfig));
+        }
+        return sources;
+    }
+
+    // ── Columns ────────────────────────────────────────────────────
+
+    private buildColumns(): CustomColumn[] {
+        return [
+            {
+                key: 'security',
+                header: 'Sec',
+                width: 100,
+                filter: 'list',
+                filterValues: SEVERITY_LABELS,
+                getValue: (ctx) => {
+                    const merged = this.mergeFindings(ctx);
+                    if (!merged.severity) return '';
+                    const label = SEVERITY_LABELS[merged.severity] ?? '';
+                    const findings = getFindings(ctx);
+                    const firstLink = findings.flatMap((f) => f.sourceLinks ?? [])[0];
+                    if (firstLink) {
+                        return `<a href="${escapeAttr(firstLink.url)}" target="_blank" rel="noopener">${label}</a>`;
+                    }
+                    return label;
+                },
+                getFilterValue: (ctx) => {
+                    const merged = this.mergeFindings(ctx);
+                    return merged.severity ?? '';
+                },
+                getTooltip: (ctx) => {
+                    const findings = getFindings(ctx);
+                    if (findings.length === 0) return '';
+                    return findings.map((f) => f.sourceLabel).join(', ');
+                },
+            },
+            {
+                key: 'securityFix',
+                header: 'Fix',
+                width: 70,
+                filter: 'list',
+                filterValues: { true: 'Yes', false: 'No' },
+                getValue: (ctx) => {
+                    const merged = this.mergeFindings(ctx);
+                    if (merged.advisoryCount === 0) return '';
+                    return merged.fixAvailable ? 'Yes' : 'No';
+                },
+                getFilterValue: (ctx) => {
+                    const merged = this.mergeFindings(ctx);
+                    if (merged.advisoryCount === 0) return '';
+                    return String(merged.fixAvailable ?? false);
+                },
+            },
+            {
+                key: 'securityWhy',
+                header: 'Security',
+                width: 280,
+                filter: 'input',
+                getValue: (ctx) => {
+                    const findings = getFindings(ctx);
+                    if (findings.length === 0) return '';
+                    const allLinks = findings.flatMap((f) => f.sourceLinks ?? []);
+                    const merged = this.mergeFindings(ctx);
+                    const parts: string[] = [];
+                    if (allLinks.length > 0) {
+                        const linkedIds = allLinks
+                            .map(
+                                (l) =>
+                                    `<a href="${escapeAttr(l.url)}" target="_blank" rel="noopener">${escapeHtml(l.label)}</a>`,
+                            )
+                            .join(', ');
+                        parts.push(linkedIds);
+                    }
+                    for (const r of merged.rationale) {
+                        if (!r.match(/^\d+ advisor/)) parts.push(escapeHtml(r));
+                    }
+                    return parts.join('; ');
+                },
+            },
+        ];
+    }
+
+    // ── Sections (for grouping detail pages) ───────────────────────
+
+    getSections = (ctx: GroupingDetailContext): GroupingSection[] => {
+        const { dependencies, store } = ctx;
+        let withAdvisories = 0;
+        let withFixes = 0;
+        let clean = 0;
+
+        for (const dep of dependencies) {
+            for (const ver of dep.versions) {
+                const scoped = store.scoped(dep.ecosystem);
+                const findings =
+                    scoped.getVersionFact<SecurityFinding[]>(
+                        dep.name,
+                        ver.version,
+                        SECURITY_FINDINGS_KEY,
+                    ) ?? [];
+                if (findings.length === 0) {
+                    clean++;
+                } else {
+                    withAdvisories++;
+                    if (findings.some((f) => f.fixAvailable)) withFixes++;
+                }
+            }
+        }
+
+        if (withAdvisories === 0 && clean === 0) return [];
+
+        return [
+            {
+                title: 'Security',
+                stats: [
+                    { label: 'With advisories', value: withAdvisories },
+                    { label: 'Fix available', value: withFixes },
+                    { label: 'Clean', value: clean },
+                ],
+            },
+        ];
+    };
+
+    // ── Linear issue spec ──────────────────────────────────────────
+
+    getLinearIssueSpec = (
+        context: VersionContext,
+        store: FactStore,
+    ): Partial<LinearIssueSpec> | undefined => {
+        const findings =
+            store.getVersionFact<SecurityFinding[]>(
+                context.name,
+                context.currentVersion,
+                SECURITY_FINDINGS_KEY,
+            ) ?? [];
+
+        if (findings.length === 0) return undefined;
+
+        const merged = mergeFindingsFromArray(findings);
+        return {
+            descriptionSections: this.buildDescriptionSections(merged, findings),
+        };
+    };
+
+    // ── GitHub issue spec ──────────────────────────────────────────
+
+    getGitHubIssueSpec = (
+        context: GitHubVersionContext,
+        store: FactStore,
+    ): Partial<GitHubIssueSpec> | undefined => {
+        const findings =
+            store.getVersionFact<SecurityFinding[]>(
+                context.name,
+                context.currentVersion,
+                SECURITY_FINDINGS_KEY,
+            ) ?? [];
+
+        if (findings.length === 0) return undefined;
+
+        const merged = mergeFindingsFromArray(findings);
+        return {
+            descriptionSections: this.buildDescriptionSections(merged, findings),
+        };
+    };
+
+    // ── Private helpers ────────────────────────────────────────────
+
+    private mergeFindings(ctx: ColumnContext): MergedFindings {
+        const findings = getFindings(ctx);
+        return mergeFindingsFromArray(findings);
+    }
+
+    private buildDescriptionSections(
+        merged: MergedFindings,
+        findings: SecurityFinding[],
+    ): Array<{ title: string; body: string }> {
+        const sections: Array<{ title: string; body: string }> = [];
+
+        // Security summary
+        const summaryLines: string[] = [];
+        if (merged.severity) {
+            summaryLines.push(`- Severity: **${merged.severity}**`);
+        }
+        if (merged.advisoryCount > 0) {
+            summaryLines.push(`- Advisories: ${merged.advisoryCount}`);
+        }
+        summaryLines.push(`- Fix available: ${merged.fixAvailable ? 'yes' : 'no'}`);
+        sections.push({ title: 'Security summary', body: summaryLines.join('\n') });
+
+        // Why this matters
+        if (merged.rationale.length > 0) {
+            sections.push({
+                title: 'Why this matters',
+                body: merged.rationale.join('. ') + '.',
+            });
+        }
+
+        // Sources
+        const allLinks = findings.flatMap((f) => f.sourceLinks ?? []);
+        if (allLinks.length > 0) {
+            const sourceLines = allLinks.map((l) => `- [${l.label}](${l.url})`);
+            sections.push({ title: 'Sources', body: sourceLines.join('\n') });
+        }
+
+        return sections;
+    }
+}
+
+// ── Shared helpers ──────────────────────────────────────────────────
+
+const SEVERITY_LABELS: Record<string, string> = {
+    none: 'None',
+    low: 'Low',
+    medium: 'Medium',
+    high: 'High',
+    critical: 'Critical',
+};
+
+const SEVERITY_ORDER: Severity[] = ['none', 'low', 'medium', 'high', 'critical'];
+
+interface MergedFindings {
+    severity: Severity | undefined;
+    advisoryCount: number;
+    fixAvailable: boolean;
+    rationale: string[];
+}
+
+function getFindings(ctx: ColumnContext): SecurityFinding[] {
+    return (
+        ctx.store.getVersionFact<SecurityFinding[]>(
+            ctx.name,
+            ctx.version.version,
+            SECURITY_FINDINGS_KEY,
+        ) ?? []
+    );
+}
+
+function mergeFindingsFromArray(findings: SecurityFinding[]): MergedFindings {
+    if (findings.length === 0) {
+        return { severity: undefined, advisoryCount: 0, fixAvailable: false, rationale: [] };
+    }
+
+    const severities = findings
+        .map((f) => f.severity)
+        .filter((s): s is Severity => s !== undefined);
+
+    let worstSeverity: Severity | undefined;
+    if (severities.length > 0) {
+        let worst = 0;
+        for (const s of severities) {
+            const idx = SEVERITY_ORDER.indexOf(s);
+            if (idx > worst) worst = idx;
+        }
+        worstSeverity = SEVERITY_ORDER[worst];
+    }
+
+    const totalAdvisories = findings.reduce((sum, f) => sum + (f.advisoryCount ?? 0), 0);
+    const anyFix = findings.some((f) => f.fixAvailable);
+    const allRationale = findings.flatMap((f) => f.rationale ?? []);
+
+    return {
+        severity: worstSeverity,
+        advisoryCount: totalAdvisories,
+        fixAvailable: anyFix,
+        rationale: allRationale,
+    };
+}
+
+function escapeAttr(s: string): string {
+    return s
+        .replace(/&/g, '&amp;')
+        .replace(/"/g, '&quot;')
+        .replace(/</g, '&lt;')
+        .replace(/>/g, '&gt;');
+}
+
+function escapeHtml(s: string): string {
+    return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,4 +1,15 @@
 export { SecurityPlugin } from './SecurityPlugin';
-export type { SecurityPluginConfig, OsvConfig, SecurityFinding, Severity } from './types';
+export type {
+    SecurityPluginConfig,
+    OsvConfig,
+    DepsDevConfig,
+    GitHubAdvisoryConfig,
+    SecurityFinding,
+    AdvisoryDetail,
+    Severity,
+    Maintenance,
+} from './types';
 export { SECURITY_FINDINGS_KEY, SEVERITY_ORDER } from './types';
 export { OsvSource } from './sources/OsvSource';
+export { DepsDevSource } from './sources/DepsDevSource';
+export { GitHubAdvisorySource } from './sources/GitHubAdvisorySource';

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,0 +1,4 @@
+export { SecurityPlugin } from './SecurityPlugin';
+export type { SecurityPluginConfig, OsvConfig, SecurityFinding, Severity } from './types';
+export { SECURITY_FINDINGS_KEY } from './types';
+export { OsvSource } from './sources/OsvSource';

--- a/packages/security/src/index.ts
+++ b/packages/security/src/index.ts
@@ -1,4 +1,4 @@
 export { SecurityPlugin } from './SecurityPlugin';
 export type { SecurityPluginConfig, OsvConfig, SecurityFinding, Severity } from './types';
-export { SECURITY_FINDINGS_KEY } from './types';
+export { SECURITY_FINDINGS_KEY, SEVERITY_ORDER } from './types';
 export { OsvSource } from './sources/OsvSource';

--- a/packages/security/src/sources/DepsDevSource.test.ts
+++ b/packages/security/src/sources/DepsDevSource.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect } from 'vitest';
+import { ECOSYSTEM_MAP, deriveMaintenance } from './DepsDevSource';
+
+describe('ECOSYSTEM_MAP', () => {
+    it('maps npm to NPM', () => expect(ECOSYSTEM_MAP['npm']).toBe('NPM'));
+    it('maps pypi to PYPI', () => expect(ECOSYSTEM_MAP['pypi']).toBe('PYPI'));
+    it('maps gomod to GO', () => expect(ECOSYSTEM_MAP['gomod']).toBe('GO'));
+    it('maps cargo to CARGO', () => expect(ECOSYSTEM_MAP['cargo']).toBe('CARGO'));
+    it('returns undefined for mise', () => expect(ECOSYSTEM_MAP['mise']).toBeUndefined());
+});
+
+describe('deriveMaintenance', () => {
+    it('returns stale for deprecated packages', () => {
+        expect(deriveMaintenance({ isDefault: true, isDeprecated: true })).toBe('stale');
+    });
+
+    it('returns active for non-deprecated packages', () => {
+        expect(deriveMaintenance({ isDefault: true, isDeprecated: false })).toBe('active');
+        expect(deriveMaintenance({ isDefault: false, isDeprecated: false })).toBe('active');
+        expect(deriveMaintenance({})).toBe('active');
+    });
+
+    it('treats deprecated as stale regardless of isDefault', () => {
+        expect(deriveMaintenance({ isDefault: false, isDeprecated: true })).toBe('stale');
+        expect(deriveMaintenance({ isDefault: true, isDeprecated: true })).toBe('stale');
+    });
+});

--- a/packages/security/src/sources/DepsDevSource.ts
+++ b/packages/security/src/sources/DepsDevSource.ts
@@ -1,0 +1,198 @@
+import type { CacheService, DataSource, DirectDependency, FactStore } from '@dependicus/core';
+import type { SecurityFinding, Maintenance, DepsDevConfig } from '../types';
+import { SECURITY_FINDINGS_KEY } from '../types';
+
+// ── Ecosystem mapping ───────────────────────────────────────────────
+
+/** Map dependicus ecosystem names to deps.dev system names (uppercase). */
+export const ECOSYSTEM_MAP: Record<string, string> = {
+    npm: 'NPM',
+    pypi: 'PYPI',
+    gomod: 'GO',
+    cargo: 'CARGO',
+};
+
+/** Systems where the :dependencies endpoint is available. */
+const DEPS_SUPPORTED_SYSTEMS = new Set(['NPM', 'CARGO', 'PYPI']);
+
+// ── API types ───────────────────────────────────────────────────────
+
+interface DepsDevVersionResponse {
+    isDefault?: boolean;
+    isDeprecated?: boolean;
+    deprecatedReason?: string;
+    links?: Array<{ label: string; url: string }>;
+}
+
+interface DepsDevDependenciesResponse {
+    nodes?: Array<{
+        relation?: string; // SELF, DIRECT, INDIRECT
+    }>;
+}
+
+// ── DepsDevSource ───────────────────────────────────────────────────
+
+const API_BASE = 'https://api.deps.dev/v3';
+const FETCH_TIMEOUT_MS = 30_000;
+const DEFAULT_CACHE_TTL_DAYS = 7;
+
+interface CachedEntry<T> {
+    fetchedAt: number;
+    data: T;
+}
+
+export class DepsDevSource implements DataSource {
+    readonly name = 'deps-dev';
+    readonly dependsOn: readonly string[] = [];
+
+    private readonly includeDependencies: boolean;
+    private readonly cacheTtlMs: number;
+    private cacheService: CacheService | undefined;
+
+    constructor(config?: DepsDevConfig) {
+        this.includeDependencies = config?.includeDependencies ?? true;
+        this.cacheTtlMs = (config?.cacheTtlDays ?? DEFAULT_CACHE_TTL_DAYS) * 24 * 60 * 60 * 1000;
+    }
+
+    setCacheService(cs: CacheService): void {
+        this.cacheService = cs;
+    }
+
+    async fetch(dependencies: DirectDependency[], store: FactStore): Promise<void> {
+        const work: Array<{ dep: DirectDependency; version: string; system: string }> = [];
+
+        for (const dep of dependencies) {
+            const system = ECOSYSTEM_MAP[dep.ecosystem];
+            if (!system) continue;
+            for (const ver of dep.versions) {
+                work.push({ dep, version: ver.version, system });
+            }
+        }
+
+        if (work.length === 0) return;
+
+        process.stderr.write(`deps.dev: querying ${work.length} package versions...\n`);
+
+        let enriched = 0;
+        const concurrency = 10;
+        for (let i = 0; i < work.length; i += concurrency) {
+            const batch = work.slice(i, i + concurrency);
+            await Promise.all(
+                batch.map(async ({ dep, version, system }) => {
+                    const finding = await this.fetchFinding(dep.name, version, system);
+                    if (!finding) return;
+
+                    const scoped = store.scoped(dep.ecosystem);
+                    const existing =
+                        scoped.getVersionFact<SecurityFinding[]>(
+                            dep.name,
+                            version,
+                            SECURITY_FINDINGS_KEY,
+                        ) ?? [];
+                    scoped.setVersionFact(dep.name, version, SECURITY_FINDINGS_KEY, [
+                        ...existing,
+                        finding,
+                    ]);
+                    enriched++;
+                }),
+            );
+        }
+
+        process.stderr.write(`deps.dev: enriched ${enriched} package versions\n`);
+    }
+
+    private async fetchFinding(
+        name: string,
+        version: string,
+        system: string,
+    ): Promise<SecurityFinding | undefined> {
+        const encodedName = encodeURIComponent(name);
+        const encodedVersion = encodeURIComponent(version);
+
+        // Fetch version info
+        const versionData = await this.cachedFetch<DepsDevVersionResponse>(
+            `depsdev-version-${system}-${name}-${version}`,
+            `${API_BASE}/systems/${system}/packages/${encodedName}/versions/${encodedVersion}`,
+        );
+        if (!versionData) return undefined;
+
+        // Optionally fetch dependency graph
+        let depCount: { direct: number; total: number } | undefined;
+        if (this.includeDependencies && DEPS_SUPPORTED_SYSTEMS.has(system)) {
+            const depsData = await this.cachedFetch<DepsDevDependenciesResponse>(
+                `depsdev-deps-${system}-${name}-${version}`,
+                `${API_BASE}/systems/${system}/packages/${encodedName}/versions/${encodedVersion}:dependencies`,
+            );
+            if (depsData?.nodes) {
+                const direct = depsData.nodes.filter((n) => n.relation === 'DIRECT').length;
+                const total = depsData.nodes.filter((n) => n.relation !== 'SELF').length;
+                depCount = { direct, total };
+            }
+        }
+
+        // Derive maintenance posture
+        const maintenance = deriveMaintenance(versionData);
+
+        // Build rationale
+        const rationale: string[] = [];
+        if (versionData.isDeprecated) {
+            rationale.push(
+                versionData.deprecatedReason
+                    ? `deprecated: ${versionData.deprecatedReason}`
+                    : 'deprecated',
+            );
+        }
+        // isDefault === false just means "not on latest", which dependicus
+        // already surfaces. Only the deprecated signal is worth calling out.
+        if (depCount && depCount.total > 0) {
+            rationale.push(
+                `${depCount.direct} direct ${depCount.direct === 1 ? 'dependency' : 'dependencies'}, ${depCount.total} total transitive`,
+            );
+        }
+
+        return {
+            source: 'deps-dev',
+            sourceLabel: 'deps.dev',
+            maintenance,
+            rationale,
+        };
+    }
+
+    private async cachedFetch<T>(cacheKey: string, url: string): Promise<T | undefined> {
+        if (this.cacheService) {
+            const raw = await this.cacheService.readPermanentCache(cacheKey);
+            if (raw) {
+                const cached = JSON.parse(raw) as CachedEntry<T>;
+                if (Date.now() - cached.fetchedAt < this.cacheTtlMs) {
+                    return cached.data;
+                }
+            }
+        }
+
+        try {
+            const response = await fetch(url, {
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            });
+            if (!response.ok) return undefined;
+            const data = (await response.json()) as T;
+
+            if (this.cacheService) {
+                const envelope: CachedEntry<T> = { fetchedAt: Date.now(), data };
+                await this.cacheService.writePermanentCache(cacheKey, JSON.stringify(envelope));
+            }
+
+            return data;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+export function deriveMaintenance(data: DepsDevVersionResponse): Maintenance {
+    if (data.isDeprecated) return 'stale';
+    // If deps.dev knows about this package and it's not deprecated,
+    // the project is actively maintained enough to publish to a registry.
+    return 'active';
+}

--- a/packages/security/src/sources/GitHubAdvisorySource.test.ts
+++ b/packages/security/src/sources/GitHubAdvisorySource.test.ts
@@ -1,0 +1,20 @@
+import { describe, it, expect } from 'vitest';
+import { ECOSYSTEM_MAP, mapSeverity } from './GitHubAdvisorySource';
+
+describe('ECOSYSTEM_MAP', () => {
+    it('maps npm to npm', () => expect(ECOSYSTEM_MAP['npm']).toBe('npm'));
+    it('maps pypi to pip', () => expect(ECOSYSTEM_MAP['pypi']).toBe('pip'));
+    it('maps gomod to go', () => expect(ECOSYSTEM_MAP['gomod']).toBe('go'));
+    it('maps cargo to rust', () => expect(ECOSYSTEM_MAP['cargo']).toBe('rust'));
+    it('returns undefined for mise', () => expect(ECOSYSTEM_MAP['mise']).toBeUndefined());
+});
+
+describe('mapSeverity', () => {
+    it('maps critical', () => expect(mapSeverity('critical')).toBe('critical'));
+    it('maps high', () => expect(mapSeverity('high')).toBe('high'));
+    it('maps medium', () => expect(mapSeverity('medium')).toBe('medium'));
+    it('maps low', () => expect(mapSeverity('low')).toBe('low'));
+    it('handles uppercase', () => expect(mapSeverity('HIGH')).toBe('high'));
+    it('returns undefined for unknown', () => expect(mapSeverity('unknown')).toBeUndefined());
+    it('returns undefined for empty string', () => expect(mapSeverity('')).toBeUndefined());
+});

--- a/packages/security/src/sources/GitHubAdvisorySource.ts
+++ b/packages/security/src/sources/GitHubAdvisorySource.ts
@@ -1,0 +1,229 @@
+import type { CacheService, DataSource, DirectDependency, FactStore } from '@dependicus/core';
+import type { AdvisoryDetail, SecurityFinding, Severity, GitHubAdvisoryConfig } from '../types';
+import { SECURITY_FINDINGS_KEY } from '../types';
+
+// ── Ecosystem mapping ───────────────────────────────────────────────
+
+/** Map dependicus ecosystem names to GitHub Advisory ecosystem names. */
+export const ECOSYSTEM_MAP: Record<string, string> = {
+    npm: 'npm',
+    pypi: 'pip',
+    gomod: 'go',
+    cargo: 'rust',
+};
+
+// ── API types ───────────────────────────────────────────────────────
+
+interface GitHubAdvisory {
+    ghsa_id: string;
+    summary?: string;
+    severity: string;
+    cvss?: { vector_string?: string; score?: number };
+    vulnerabilities?: Array<{
+        package?: { name: string; ecosystem: string };
+        vulnerable_version_range?: string;
+        first_patched_version?: { identifier: string } | null;
+    }>;
+}
+
+// ── GitHubAdvisorySource ────────────────────────────────────────────
+
+const API_BASE = 'https://api.github.com/advisories';
+const FETCH_TIMEOUT_MS = 30_000;
+const DEFAULT_CACHE_TTL_DAYS = 7;
+
+interface CachedEntry<T> {
+    fetchedAt: number;
+    data: T;
+}
+
+export class GitHubAdvisorySource implements DataSource {
+    readonly name = 'github-advisory';
+    readonly dependsOn: readonly string[] = [];
+
+    private readonly cacheTtlMs: number;
+    private cacheService: CacheService | undefined;
+
+    constructor(config?: GitHubAdvisoryConfig) {
+        this.cacheTtlMs = (config?.cacheTtlDays ?? DEFAULT_CACHE_TTL_DAYS) * 24 * 60 * 60 * 1000;
+    }
+
+    setCacheService(cs: CacheService): void {
+        this.cacheService = cs;
+    }
+
+    async fetch(dependencies: DirectDependency[], store: FactStore): Promise<void> {
+        const work: Array<{ dep: DirectDependency; version: string; ghEcosystem: string }> = [];
+
+        for (const dep of dependencies) {
+            const ghEcosystem = ECOSYSTEM_MAP[dep.ecosystem];
+            if (!ghEcosystem) continue;
+            for (const ver of dep.versions) {
+                work.push({ dep, version: ver.version, ghEcosystem });
+            }
+        }
+
+        if (work.length === 0) return;
+
+        process.stderr.write(`GitHub Advisory: querying ${work.length} package versions...\n`);
+
+        let enriched = 0;
+        const concurrency = 5; // Lower than OSV — respect GitHub rate limits
+        for (let i = 0; i < work.length; i += concurrency) {
+            const batch = work.slice(i, i + concurrency);
+            await Promise.all(
+                batch.map(async ({ dep, version, ghEcosystem }) => {
+                    const finding = await this.fetchFinding(dep.name, version, ghEcosystem);
+                    if (!finding) return;
+
+                    const scoped = store.scoped(dep.ecosystem);
+                    const existing =
+                        scoped.getVersionFact<SecurityFinding[]>(
+                            dep.name,
+                            version,
+                            SECURITY_FINDINGS_KEY,
+                        ) ?? [];
+                    scoped.setVersionFact(dep.name, version, SECURITY_FINDINGS_KEY, [
+                        ...existing,
+                        finding,
+                    ]);
+                    enriched++;
+                }),
+            );
+        }
+
+        process.stderr.write(`GitHub Advisory: enriched ${enriched} package versions\n`);
+    }
+
+    private async fetchFinding(
+        name: string,
+        version: string,
+        ghEcosystem: string,
+    ): Promise<SecurityFinding | undefined> {
+        const affects = `${name}@${version}`;
+        const url = `${API_BASE}?ecosystem=${encodeURIComponent(ghEcosystem)}&affects=${encodeURIComponent(affects)}&per_page=100`;
+        const cacheKey = `ghsa-${ghEcosystem}-${name}-${version}`;
+
+        const advisories = await this.cachedFetch<GitHubAdvisory[]>(cacheKey, url);
+        if (!advisories || advisories.length === 0) return undefined;
+
+        // Compute worst severity and highest CVSS score
+        let worstSeverity: Severity | undefined;
+        let highestScore: number | undefined;
+
+        for (const advisory of advisories) {
+            const sev = mapSeverity(advisory.severity);
+            if (sev && (!worstSeverity || severityRank(sev) > severityRank(worstSeverity))) {
+                worstSeverity = sev;
+            }
+            if (advisory.cvss?.score !== undefined) {
+                if (highestScore === undefined || advisory.cvss.score > highestScore) {
+                    highestScore = advisory.cvss.score;
+                }
+            }
+        }
+
+        // Check if any advisory has a patched version
+        const fixAvailable = advisories.some((a) =>
+            a.vulnerabilities?.some((v) => v.first_patched_version != null),
+        );
+
+        const advisoryIds = advisories.map((a) => a.ghsa_id);
+        const rationale: string[] = [];
+        if (advisories.length === 1) {
+            rationale.push(`1 GitHub advisory (${advisories[0]!.ghsa_id})`);
+        } else {
+            rationale.push(`${advisories.length} GitHub advisories`);
+        }
+        if (fixAvailable) {
+            rationale.push('fix available');
+        }
+
+        const sourceLinks = advisories.map((a) => ({
+            label: a.ghsa_id,
+            url: `https://github.com/advisories/${a.ghsa_id}`,
+        }));
+
+        const advisoryDetails: AdvisoryDetail[] = advisories.map((a) => ({
+            id: a.ghsa_id,
+            summary: a.summary,
+            severity: mapSeverity(a.severity),
+            cvssScore: a.cvss?.score,
+            fixAvailable: a.vulnerabilities?.some((v) => v.first_patched_version != null) ?? false,
+            url: `https://github.com/advisories/${a.ghsa_id}`,
+        }));
+
+        return {
+            source: 'github-advisory',
+            sourceLabel: 'GitHub Advisory',
+            severity: worstSeverity,
+            cvssScore: highestScore,
+            advisories: advisoryDetails,
+            advisoryIds,
+            advisoryCount: advisories.length,
+            fixAvailable,
+            rationale,
+            sourceLinks,
+        };
+    }
+
+    private async cachedFetch<T>(cacheKey: string, url: string): Promise<T | undefined> {
+        if (this.cacheService) {
+            const raw = await this.cacheService.readPermanentCache(cacheKey);
+            if (raw) {
+                const cached = JSON.parse(raw) as CachedEntry<T>;
+                if (Date.now() - cached.fetchedAt < this.cacheTtlMs) {
+                    return cached.data;
+                }
+            }
+        }
+
+        try {
+            const headers: Record<string, string> = {
+                Accept: 'application/vnd.github+json',
+            };
+            // Use GITHUB_TOKEN if available for higher rate limits (5000/hr vs 60/hr)
+            const token = process.env.GITHUB_TOKEN;
+            if (token) {
+                headers['Authorization'] = `Bearer ${token}`;
+            }
+
+            const response = await fetch(url, {
+                headers,
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            });
+            if (!response.ok) return undefined;
+            const data = (await response.json()) as T;
+
+            if (this.cacheService) {
+                const envelope: CachedEntry<T> = { fetchedAt: Date.now(), data };
+                await this.cacheService.writePermanentCache(cacheKey, JSON.stringify(envelope));
+            }
+
+            return data;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const SEVERITY_RANK: Record<string, number> = {
+    low: 1,
+    medium: 2,
+    high: 3,
+    critical: 4,
+};
+
+export function mapSeverity(ghSeverity: string): Severity | undefined {
+    const lower = ghSeverity.toLowerCase();
+    if (lower === 'critical' || lower === 'high' || lower === 'medium' || lower === 'low') {
+        return lower;
+    }
+    return undefined;
+}
+
+function severityRank(s: Severity): number {
+    return SEVERITY_RANK[s] ?? 0;
+}

--- a/packages/security/src/sources/OsvSource.test.ts
+++ b/packages/security/src/sources/OsvSource.test.ts
@@ -1,0 +1,164 @@
+import { describe, it, expect } from 'vitest';
+import {
+    severityFromScore,
+    cvssBaseScore,
+    parseSeverity,
+    hasFixedVersion,
+    pickWorstSeverity,
+    ECOSYSTEM_MAP,
+} from './OsvSource';
+import type { OsvVulnerability } from './OsvSource';
+
+describe('severityFromScore', () => {
+    it('maps 0 to none', () => expect(severityFromScore(0)).toBe('none'));
+    it('maps 0.1 to low', () => expect(severityFromScore(0.1)).toBe('low'));
+    it('maps 3.9 to low', () => expect(severityFromScore(3.9)).toBe('low'));
+    it('maps 4.0 to medium', () => expect(severityFromScore(4.0)).toBe('medium'));
+    it('maps 6.9 to medium', () => expect(severityFromScore(6.9)).toBe('medium'));
+    it('maps 7.0 to high', () => expect(severityFromScore(7.0)).toBe('high'));
+    it('maps 8.9 to high', () => expect(severityFromScore(8.9)).toBe('high'));
+    it('maps 9.0 to critical', () => expect(severityFromScore(9.0)).toBe('critical'));
+    it('maps 10.0 to critical', () => expect(severityFromScore(10.0)).toBe('critical'));
+});
+
+describe('cvssBaseScore', () => {
+    it('parses a CVSS v3.1 vector', () => {
+        const score = cvssBaseScore('CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H');
+        expect(score).toBe(10.0);
+    });
+
+    it('parses a CVSS v4.0 vector', () => {
+        const score = cvssBaseScore(
+            'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H',
+        );
+        expect(score).toBeGreaterThanOrEqual(9.0);
+    });
+
+    it('parses a CVSS v2 vector', () => {
+        const score = cvssBaseScore('AV:N/AC:L/Au:N/C:C/I:C/A:C');
+        expect(score).toBe(10.0);
+    });
+
+    it('returns undefined for garbage input', () => {
+        expect(cvssBaseScore('not-a-vector')).toBeUndefined();
+    });
+
+    it('returns undefined for empty string', () => {
+        expect(cvssBaseScore('')).toBeUndefined();
+    });
+});
+
+describe('parseSeverity', () => {
+    it('returns undefined for empty array', () => {
+        expect(parseSeverity([])).toBeUndefined();
+    });
+
+    it('returns undefined for undefined input', () => {
+        expect(parseSeverity(undefined)).toBeUndefined();
+    });
+
+    it('prefers CVSS_V3 over CVSS_V4', () => {
+        const result = parseSeverity([
+            {
+                type: 'CVSS_V4',
+                score: 'CVSS:4.0/AV:P/AC:H/AT:P/PR:H/UI:A/VC:N/VI:N/VA:N/SC:N/SI:N/SA:N',
+            },
+            { type: 'CVSS_V3', score: 'CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:C/C:H/I:H/A:H' },
+        ]);
+        expect(result).toBe('critical');
+    });
+
+    it('uses CVSS_V4 when V3 is absent', () => {
+        const result = parseSeverity([
+            {
+                type: 'CVSS_V4',
+                score: 'CVSS:4.0/AV:N/AC:L/AT:N/PR:N/UI:N/VC:H/VI:H/VA:H/SC:H/SI:H/SA:H',
+            },
+        ]);
+        expect(result).toBe('critical');
+    });
+
+    it('uses CVSS_V2 when V3 and V4 are absent', () => {
+        const result = parseSeverity([{ type: 'CVSS_V2', score: 'AV:N/AC:L/Au:N/C:C/I:C/A:C' }]);
+        expect(result).toBe('critical');
+    });
+
+    it('falls back to medium for unknown type', () => {
+        expect(parseSeverity([{ type: 'UNKNOWN', score: 'whatever' }])).toBe('medium');
+    });
+
+    it('skips unparseable vectors and falls back', () => {
+        // V3 entry with garbage vector, V2 entry with valid vector
+        const result = parseSeverity([
+            { type: 'CVSS_V3', score: 'garbage' },
+            { type: 'CVSS_V2', score: 'AV:N/AC:L/Au:N/C:C/I:C/A:C' },
+        ]);
+        expect(result).toBe('critical');
+    });
+});
+
+describe('hasFixedVersion', () => {
+    it('returns true when a fixed event exists', () => {
+        const vuln: OsvVulnerability = {
+            id: 'TEST-001',
+            affected: [
+                {
+                    ranges: [
+                        {
+                            type: 'ECOSYSTEM',
+                            events: [{ introduced: '0' }, { fixed: '1.2.3' }],
+                        },
+                    ],
+                },
+            ],
+        };
+        expect(hasFixedVersion(vuln)).toBe(true);
+    });
+
+    it('returns false when no fixed event exists', () => {
+        const vuln: OsvVulnerability = {
+            id: 'TEST-002',
+            affected: [
+                {
+                    ranges: [
+                        {
+                            type: 'ECOSYSTEM',
+                            events: [{ introduced: '0' }],
+                        },
+                    ],
+                },
+            ],
+        };
+        expect(hasFixedVersion(vuln)).toBe(false);
+    });
+
+    it('returns false for empty affected', () => {
+        expect(hasFixedVersion({ id: 'TEST-003' })).toBe(false);
+    });
+});
+
+describe('pickWorstSeverity', () => {
+    it('returns undefined for empty array', () => {
+        expect(pickWorstSeverity([])).toBeUndefined();
+    });
+
+    it('returns the single severity', () => {
+        expect(pickWorstSeverity(['low'])).toBe('low');
+    });
+
+    it('picks the worst from mixed severities', () => {
+        expect(pickWorstSeverity(['low', 'critical', 'medium'])).toBe('critical');
+    });
+
+    it('returns none when all are none', () => {
+        expect(pickWorstSeverity(['none', 'none'])).toBe('none');
+    });
+});
+
+describe('ECOSYSTEM_MAP', () => {
+    it('maps npm to npm', () => expect(ECOSYSTEM_MAP['npm']).toBe('npm'));
+    it('maps pypi to PyPI', () => expect(ECOSYSTEM_MAP['pypi']).toBe('PyPI'));
+    it('maps gomod to Go', () => expect(ECOSYSTEM_MAP['gomod']).toBe('Go'));
+    it('maps cargo to crates.io', () => expect(ECOSYSTEM_MAP['cargo']).toBe('crates.io'));
+    it('returns undefined for mise', () => expect(ECOSYSTEM_MAP['mise']).toBeUndefined());
+});

--- a/packages/security/src/sources/OsvSource.ts
+++ b/packages/security/src/sources/OsvSource.ts
@@ -1,0 +1,318 @@
+import type { CacheService, DataSource, DirectDependency, FactStore } from '@dependicus/core';
+import type { SecurityFinding, Severity, OsvConfig } from '../types';
+import { SECURITY_FINDINGS_KEY } from '../types';
+
+// ── OSV ecosystem mapping ───────────────────────────────────────────
+
+/** Map dependicus ecosystem names to OSV ecosystem names. */
+const ECOSYSTEM_MAP: Record<string, string> = {
+    npm: 'npm',
+    pypi: 'PyPI',
+    gomod: 'Go',
+    cargo: 'crates.io',
+};
+
+// ── OSV API types ───────────────────────────────────────────────────
+
+interface OsvBatchQuery {
+    package: { name: string; ecosystem: string };
+    version: string;
+}
+
+interface OsvBatchResponse {
+    results: Array<{
+        vulns?: Array<{ id: string; modified: string }>;
+    }>;
+}
+
+interface OsvVulnerability {
+    id: string;
+    summary?: string;
+    severity?: Array<{ type: string; score: string }>;
+    affected?: Array<{
+        package?: { name: string; ecosystem: string };
+        ranges?: Array<{
+            type: string;
+            events: Array<Record<string, string>>;
+        }>;
+    }>;
+    references?: Array<{ type: string; url: string }>;
+}
+
+// ── CVSS parsing ────────────────────────────────────────────────────
+
+/** Extract a severity bucket from a CVSS v3 vector string. */
+function severityFromCvssV3(vector: string): Severity {
+    // CVSS:3.x/AV:.../...  — we need the base score, but the vector doesn't
+    // contain a numeric score directly. Parse the base metrics to approximate.
+    // Instead, look for an explicit score suffix some databases append, or
+    // fall back to a heuristic based on the attack vector + privileges.
+    //
+    // Simpler: many OSV entries also put ecosystem_specific severity.
+    // But as a robust fallback, parse the vector properly.
+    //
+    // CVSS v3 vector → base score approximation is complex. Instead, check
+    // if the vector string itself contains a trailing score (some providers
+    // append it). Otherwise, use a rough heuristic from attack complexity.
+    const acMatch = vector.match(/AC:([HLM])/);
+    const avMatch = vector.match(/AV:([NALP])/);
+    const prMatch = vector.match(/PR:([NLH])/);
+    const cMatch = vector.match(/C:([NLH])/);
+    const iMatch = vector.match(/I:([NLH])/);
+    const aMatch = vector.match(/A:([NLH])/);
+
+    // Simple weighted heuristic — not a real CVSS calculator, but good enough
+    // to bucket into none/low/medium/high/critical.
+    let score = 0;
+    if (avMatch?.[1] === 'N') score += 3;
+    else if (avMatch?.[1] === 'A') score += 2;
+    else if (avMatch?.[1] === 'L') score += 1;
+
+    if (acMatch?.[1] === 'L') score += 1;
+
+    if (prMatch?.[1] === 'N') score += 2;
+    else if (prMatch?.[1] === 'L') score += 1;
+
+    const impactLetters = [cMatch?.[1], iMatch?.[1], aMatch?.[1]];
+    for (const l of impactLetters) {
+        if (l === 'H') score += 2;
+        else if (l === 'L') score += 1;
+    }
+
+    // Max possible ~12, map to buckets
+    if (score >= 10) return 'critical';
+    if (score >= 7) return 'high';
+    if (score >= 4) return 'medium';
+    if (score >= 1) return 'low';
+    return 'none';
+}
+
+function parseSeverity(
+    severityEntries: Array<{ type: string; score: string }> | undefined,
+): Severity | undefined {
+    if (!severityEntries || severityEntries.length === 0) return undefined;
+
+    // Prefer CVSS_V3 over V4 over V2
+    const v3 = severityEntries.find((s) => s.type === 'CVSS_V3');
+    if (v3) return severityFromCvssV3(v3.score);
+
+    const v4 = severityEntries.find((s) => s.type === 'CVSS_V4');
+    if (v4) return severityFromCvssV3(v4.score); // V4 vectors have similar structure
+
+    // For V2 or unknown, default to medium
+    return 'medium';
+}
+
+/** Check whether any affected range has a "fixed" event. */
+function hasFixedVersion(vuln: OsvVulnerability): boolean {
+    for (const affected of vuln.affected ?? []) {
+        for (const range of affected.ranges ?? []) {
+            for (const event of range.events) {
+                if ('fixed' in event) return true;
+            }
+        }
+    }
+    return false;
+}
+
+// ── OsvSource ───────────────────────────────────────────────────────
+
+const OSV_BATCH_URL = 'https://api.osv.dev/v1/querybatch';
+const OSV_VULN_URL = 'https://api.osv.dev/v1/vulns';
+
+export class OsvSource implements DataSource {
+    readonly name = 'osv';
+    readonly dependsOn: readonly string[] = [];
+
+    private readonly batchSize: number;
+    private cacheService: CacheService | undefined;
+
+    constructor(config?: OsvConfig) {
+        this.batchSize = config?.batchSize ?? 1000;
+    }
+
+    setCacheService(cs: CacheService): void {
+        this.cacheService = cs;
+    }
+
+    async fetch(dependencies: DirectDependency[], store: FactStore): Promise<void> {
+        // Build the list of queries, tracking which index maps to which dep+version
+        const queries: OsvBatchQuery[] = [];
+        const queryIndex: Array<{ dep: DirectDependency; version: string }> = [];
+
+        for (const dep of dependencies) {
+            const osvEcosystem = ECOSYSTEM_MAP[dep.ecosystem];
+            if (!osvEcosystem) continue;
+
+            for (const ver of dep.versions) {
+                queries.push({
+                    package: { name: dep.name, ecosystem: osvEcosystem },
+                    version: ver.version,
+                });
+                queryIndex.push({ dep, version: ver.version });
+            }
+        }
+
+        if (queries.length === 0) return;
+
+        process.stderr.write(`OSV: querying ${queries.length} package versions...\n`);
+
+        // Step 1: Batch query to find which packages have vulns
+        const vulnIdsByIndex = new Map<number, string[]>();
+        const allVulnIds = new Set<string>();
+
+        for (let i = 0; i < queries.length; i += this.batchSize) {
+            const batch = queries.slice(i, i + this.batchSize);
+            const response = await this.batchQuery(batch);
+
+            for (let j = 0; j < response.results.length; j++) {
+                const result = response.results[j];
+                if (!result?.vulns || result.vulns.length === 0) continue;
+
+                const globalIdx = i + j;
+                const ids = result.vulns.map((v) => v.id);
+                vulnIdsByIndex.set(globalIdx, ids);
+                for (const id of ids) allVulnIds.add(id);
+            }
+        }
+
+        if (allVulnIds.size === 0) {
+            process.stderr.write('OSV: no vulnerabilities found\n');
+            return;
+        }
+
+        process.stderr.write(
+            `OSV: found ${allVulnIds.size} unique vulnerabilities, fetching details...\n`,
+        );
+
+        // Step 2: Fetch full vulnerability details for each unique ID
+        const vulnDetails = new Map<string, OsvVulnerability>();
+        const idArray = Array.from(allVulnIds);
+
+        // Fetch in parallel with a concurrency limit
+        const concurrency = 10;
+        for (let i = 0; i < idArray.length; i += concurrency) {
+            const batch = idArray.slice(i, i + concurrency);
+            const results = await Promise.all(batch.map((id) => this.fetchVuln(id)));
+            for (const vuln of results) {
+                if (vuln) vulnDetails.set(vuln.id, vuln);
+            }
+        }
+
+        // Step 3: Reduce into SecurityFindings and write to FactStore
+        for (const [idx, vulnIds] of vulnIdsByIndex) {
+            const entry = queryIndex[idx];
+            if (!entry) continue;
+
+            const vulns = vulnIds
+                .map((id) => vulnDetails.get(id))
+                .filter((v): v is OsvVulnerability => v !== undefined);
+
+            if (vulns.length === 0) continue;
+
+            // Compute worst severity across all vulns
+            const severities = vulns
+                .map((v) => parseSeverity(v.severity))
+                .filter((s): s is Severity => s !== undefined);
+            const worstSeverity = pickWorstSeverity(severities);
+
+            // Check if any vuln has a fix
+            const anyFixAvailable = vulns.some(hasFixedVersion);
+
+            // Build rationale
+            const rationale: string[] = [];
+            if (vulns.length === 1) {
+                rationale.push(`1 advisory (${vulns[0]!.id})`);
+            } else {
+                rationale.push(`${vulns.length} advisories`);
+            }
+            if (anyFixAvailable) {
+                rationale.push('fix available in a newer version');
+            }
+
+            // Build source links
+            const sourceLinks = vulns.map((v) => ({
+                label: v.id,
+                url: `https://osv.dev/vulnerability/${v.id}`,
+            }));
+
+            const finding: SecurityFinding = {
+                source: 'osv',
+                sourceLabel: 'OSV',
+                severity: worstSeverity,
+                advisoryCount: vulns.length,
+                fixAvailable: anyFixAvailable,
+                rationale,
+                sourceLinks,
+            };
+
+            // Append to existing findings array
+            const scoped = store.scoped(entry.dep.ecosystem);
+            const existing =
+                scoped.getVersionFact<SecurityFinding[]>(
+                    entry.dep.name,
+                    entry.version,
+                    SECURITY_FINDINGS_KEY,
+                ) ?? [];
+            scoped.setVersionFact(entry.dep.name, entry.version, SECURITY_FINDINGS_KEY, [
+                ...existing,
+                finding,
+            ]);
+        }
+
+        process.stderr.write(
+            `OSV: enriched ${vulnIdsByIndex.size} package versions with vulnerability data\n`,
+        );
+    }
+
+    private async batchQuery(queries: OsvBatchQuery[]): Promise<OsvBatchResponse> {
+        const response = await fetch(OSV_BATCH_URL, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ queries }),
+        });
+        if (!response.ok) {
+            throw new Error(`OSV batch query failed: ${response.status} ${response.statusText}`);
+        }
+        return (await response.json()) as OsvBatchResponse;
+    }
+
+    private async fetchVuln(id: string): Promise<OsvVulnerability | undefined> {
+        const cacheKey = `osv-vuln-${id}`;
+
+        // Check cache first — vuln details are immutable once published
+        if (this.cacheService) {
+            const cached = await this.cacheService.readPermanentCache(cacheKey);
+            if (cached) return JSON.parse(cached) as OsvVulnerability;
+        }
+
+        try {
+            const response = await fetch(`${OSV_VULN_URL}/${encodeURIComponent(id)}`);
+            if (!response.ok) return undefined;
+            const vuln = (await response.json()) as OsvVulnerability;
+
+            // Cache permanently — vuln IDs are stable
+            if (this.cacheService) {
+                await this.cacheService.writePermanentCache(cacheKey, JSON.stringify(vuln));
+            }
+
+            return vuln;
+        } catch {
+            return undefined;
+        }
+    }
+}
+
+// ── Helpers ─────────────────────────────────────────────────────────
+
+const SEVERITY_ORDER: Severity[] = ['none', 'low', 'medium', 'high', 'critical'];
+
+function pickWorstSeverity(severities: Severity[]): Severity | undefined {
+    if (severities.length === 0) return undefined;
+    let worst = 0;
+    for (const s of severities) {
+        const idx = SEVERITY_ORDER.indexOf(s);
+        if (idx > worst) worst = idx;
+    }
+    return SEVERITY_ORDER[worst];
+}

--- a/packages/security/src/sources/OsvSource.ts
+++ b/packages/security/src/sources/OsvSource.ts
@@ -1,4 +1,5 @@
 import type { CacheService, DataSource, DirectDependency, FactStore } from '@dependicus/core';
+import { CVSS20, CVSS31, CVSS40 } from '@pandatix/js-cvss';
 import type { SecurityFinding, Severity, OsvConfig } from '../types';
 import { SECURITY_FINDINGS_KEY, SEVERITY_ORDER } from '../types';
 
@@ -39,128 +40,34 @@ export interface OsvVulnerability {
     references?: Array<{ type: string; url: string }>;
 }
 
-// ── CVSS parsing ────────────────────────────────────────────────────
+// ── CVSS scoring ────────────────────────────────────────────────────
 
 const FETCH_TIMEOUT_MS = 30_000;
 const DEFAULT_VULN_CACHE_TTL_DAYS = 7;
 
-/**
- * Extract a severity bucket from a CVSS v3 vector string.
- * Uses a weighted heuristic over base metrics — not a real CVSS calculator,
- * but sufficient for coarse bucketing.
- */
-export function severityFromCvssV3(vector: string): Severity {
-    const avMatch = vector.match(/AV:([NALP])/);
-    const acMatch = vector.match(/AC:([HL])/);
-    const prMatch = vector.match(/PR:([NLH])/);
-    // Use word boundary to avoid matching VC:/SC: from v4 vectors
-    const cMatch = vector.match(/\bC:([NLH])/);
-    const iMatch = vector.match(/\bI:([NLH])/);
-    const aMatch = vector.match(/\bA:([NLH])/);
-
-    let score = 0;
-    if (avMatch?.[1] === 'N') score += 3;
-    else if (avMatch?.[1] === 'A') score += 2;
-    else if (avMatch?.[1] === 'L') score += 1;
-
-    if (acMatch?.[1] === 'L') score += 1;
-
-    if (prMatch?.[1] === 'N') score += 2;
-    else if (prMatch?.[1] === 'L') score += 1;
-
-    const impactLetters = [cMatch?.[1], iMatch?.[1], aMatch?.[1]];
-    for (const l of impactLetters) {
-        if (l === 'H') score += 2;
-        else if (l === 'L') score += 1;
-    }
-
-    if (score >= 10) return 'critical';
-    if (score >= 7) return 'high';
-    if (score >= 4) return 'medium';
-    if (score >= 1) return 'low';
+/** Map a numeric CVSS base score to a severity bucket per FIRST.org thresholds. */
+export function severityFromScore(score: number): Severity {
+    if (score >= 9.0) return 'critical';
+    if (score >= 7.0) return 'high';
+    if (score >= 4.0) return 'medium';
+    if (score > 0) return 'low';
     return 'none';
 }
 
-/**
- * Extract a severity bucket from a CVSS v4 vector string.
- * V4 uses different metric names: AT (attack requirements), VC/VI/VA
- * (vulnerable system impact), SC/SI/SA (subsequent system impact).
- */
-export function severityFromCvssV4(vector: string): Severity {
-    const avMatch = vector.match(/AV:([NALP])/);
-    const atMatch = vector.match(/AT:([NP])/); // Attack Requirements: None, Present
-    const prMatch = vector.match(/PR:([NLH])/);
-    const vcMatch = vector.match(/VC:([NLH])/);
-    const viMatch = vector.match(/VI:([NLH])/);
-    const vaMatch = vector.match(/VA:([NLH])/);
-    const scMatch = vector.match(/SC:([NLH])/);
-    const siMatch = vector.match(/SI:([NLH])/);
-    const saMatch = vector.match(/SA:([NLH])/);
-
-    let score = 0;
-    if (avMatch?.[1] === 'N') score += 3;
-    else if (avMatch?.[1] === 'A') score += 2;
-    else if (avMatch?.[1] === 'L') score += 1;
-
-    if (atMatch?.[1] === 'N') score += 1; // No special requirements = easier to exploit
-
-    if (prMatch?.[1] === 'N') score += 2;
-    else if (prMatch?.[1] === 'L') score += 1;
-
-    // Vulnerable system impact (primary)
-    const vulnImpact = [vcMatch?.[1], viMatch?.[1], vaMatch?.[1]];
-    for (const l of vulnImpact) {
-        if (l === 'H') score += 2;
-        else if (l === 'L') score += 1;
+/** Compute a base score from a CVSS vector string of any version. */
+export function cvssBaseScore(vector: string): number | undefined {
+    try {
+        if (vector.startsWith('CVSS:4')) {
+            return new CVSS40(vector).Score();
+        }
+        if (vector.startsWith('CVSS:3')) {
+            return new CVSS31(vector).BaseScore();
+        }
+        // V2 vectors don't have a version prefix
+        return new CVSS20(vector).BaseScore();
+    } catch {
+        return undefined;
     }
-
-    // Subsequent system impact (secondary, weighted less)
-    const subImpact = [scMatch?.[1], siMatch?.[1], saMatch?.[1]];
-    for (const l of subImpact) {
-        if (l === 'H') score += 1;
-    }
-
-    if (score >= 10) return 'critical';
-    if (score >= 7) return 'high';
-    if (score >= 4) return 'medium';
-    if (score >= 1) return 'low';
-    return 'none';
-}
-
-/**
- * Extract a severity bucket from a CVSS v2 vector string.
- * V2 uses Au (Authentication) instead of PR, and has no scope concept.
- */
-export function severityFromCvssV2(vector: string): Severity {
-    const avMatch = vector.match(/AV:([NLA])/);
-    const acMatch = vector.match(/AC:([HML])/);
-    const auMatch = vector.match(/Au:([NSM])/);
-    const cMatch = vector.match(/\bC:([NPC])/);
-    const iMatch = vector.match(/\bI:([NPC])/);
-    const aMatch = vector.match(/\bA:([NPC])/);
-
-    let score = 0;
-    if (avMatch?.[1] === 'N') score += 3;
-    else if (avMatch?.[1] === 'A') score += 2;
-    else if (avMatch?.[1] === 'L') score += 1;
-
-    if (acMatch?.[1] === 'L') score += 1;
-
-    if (auMatch?.[1] === 'N') score += 2;
-    else if (auMatch?.[1] === 'S') score += 1;
-
-    // V2 impact uses N/P/C (None/Partial/Complete)
-    const impactLetters = [cMatch?.[1], iMatch?.[1], aMatch?.[1]];
-    for (const l of impactLetters) {
-        if (l === 'C') score += 2;
-        else if (l === 'P') score += 1;
-    }
-
-    if (score >= 10) return 'critical';
-    if (score >= 7) return 'high';
-    if (score >= 4) return 'medium';
-    if (score >= 1) return 'low';
-    return 'none';
 }
 
 export function parseSeverity(
@@ -168,16 +75,17 @@ export function parseSeverity(
 ): Severity | undefined {
     if (!severityEntries || severityEntries.length === 0) return undefined;
 
-    const v3 = severityEntries.find((s) => s.type === 'CVSS_V3');
-    if (v3) return severityFromCvssV3(v3.score);
+    // Prefer V3 > V4 > V2
+    const ordered = ['CVSS_V3', 'CVSS_V4', 'CVSS_V2'];
+    for (const type of ordered) {
+        const entry = severityEntries.find((s) => s.type === type);
+        if (entry) {
+            const score = cvssBaseScore(entry.score);
+            if (score !== undefined) return severityFromScore(score);
+        }
+    }
 
-    const v4 = severityEntries.find((s) => s.type === 'CVSS_V4');
-    if (v4) return severityFromCvssV4(v4.score);
-
-    const v2 = severityEntries.find((s) => s.type === 'CVSS_V2');
-    if (v2) return severityFromCvssV2(v2.score);
-
-    // Unknown severity type — assume medium rather than hiding it
+    // Unknown type — assume medium rather than hiding it
     return 'medium';
 }
 
@@ -317,6 +225,14 @@ export class OsvSource implements DataSource {
                 .filter((s): s is Severity => s !== undefined);
             const worstSeverity = pickWorstSeverity(severities);
 
+            // Compute highest CVSS base score across all vulns
+            const scores = vulns.flatMap((v) =>
+                (v.severity ?? [])
+                    .map((s) => cvssBaseScore(s.score))
+                    .filter((s): s is number => s !== undefined),
+            );
+            const worstScore = scores.length > 0 ? Math.max(...scores) : undefined;
+
             const anyFixAvailable = vulns.some(hasFixedVersion);
 
             const rationale: string[] = [];
@@ -338,6 +254,7 @@ export class OsvSource implements DataSource {
                 source: 'osv',
                 sourceLabel: 'OSV',
                 severity: worstSeverity,
+                cvssScore: worstScore,
                 advisoryCount: vulns.length,
                 fixAvailable: anyFixAvailable,
                 rationale,

--- a/packages/security/src/sources/OsvSource.ts
+++ b/packages/security/src/sources/OsvSource.ts
@@ -1,11 +1,11 @@
 import type { CacheService, DataSource, DirectDependency, FactStore } from '@dependicus/core';
 import type { SecurityFinding, Severity, OsvConfig } from '../types';
-import { SECURITY_FINDINGS_KEY } from '../types';
+import { SECURITY_FINDINGS_KEY, SEVERITY_ORDER } from '../types';
 
 // ── OSV ecosystem mapping ───────────────────────────────────────────
 
 /** Map dependicus ecosystem names to OSV ecosystem names. */
-const ECOSYSTEM_MAP: Record<string, string> = {
+export const ECOSYSTEM_MAP: Record<string, string> = {
     npm: 'npm',
     pypi: 'PyPI',
     gomod: 'Go',
@@ -25,7 +25,7 @@ interface OsvBatchResponse {
     }>;
 }
 
-interface OsvVulnerability {
+export interface OsvVulnerability {
     id: string;
     summary?: string;
     severity?: Array<{ type: string; score: string }>;
@@ -41,28 +41,23 @@ interface OsvVulnerability {
 
 // ── CVSS parsing ────────────────────────────────────────────────────
 
-/** Extract a severity bucket from a CVSS v3 vector string. */
-function severityFromCvssV3(vector: string): Severity {
-    // CVSS:3.x/AV:.../...  — we need the base score, but the vector doesn't
-    // contain a numeric score directly. Parse the base metrics to approximate.
-    // Instead, look for an explicit score suffix some databases append, or
-    // fall back to a heuristic based on the attack vector + privileges.
-    //
-    // Simpler: many OSV entries also put ecosystem_specific severity.
-    // But as a robust fallback, parse the vector properly.
-    //
-    // CVSS v3 vector → base score approximation is complex. Instead, check
-    // if the vector string itself contains a trailing score (some providers
-    // append it). Otherwise, use a rough heuristic from attack complexity.
-    const acMatch = vector.match(/AC:([HLM])/);
-    const avMatch = vector.match(/AV:([NALP])/);
-    const prMatch = vector.match(/PR:([NLH])/);
-    const cMatch = vector.match(/C:([NLH])/);
-    const iMatch = vector.match(/I:([NLH])/);
-    const aMatch = vector.match(/A:([NLH])/);
+const FETCH_TIMEOUT_MS = 30_000;
+const DEFAULT_VULN_CACHE_TTL_DAYS = 7;
 
-    // Simple weighted heuristic — not a real CVSS calculator, but good enough
-    // to bucket into none/low/medium/high/critical.
+/**
+ * Extract a severity bucket from a CVSS v3 vector string.
+ * Uses a weighted heuristic over base metrics — not a real CVSS calculator,
+ * but sufficient for coarse bucketing.
+ */
+export function severityFromCvssV3(vector: string): Severity {
+    const avMatch = vector.match(/AV:([NALP])/);
+    const acMatch = vector.match(/AC:([HL])/);
+    const prMatch = vector.match(/PR:([NLH])/);
+    // Use word boundary to avoid matching VC:/SC: from v4 vectors
+    const cMatch = vector.match(/\bC:([NLH])/);
+    const iMatch = vector.match(/\bI:([NLH])/);
+    const aMatch = vector.match(/\bA:([NLH])/);
+
     let score = 0;
     if (avMatch?.[1] === 'N') score += 3;
     else if (avMatch?.[1] === 'A') score += 2;
@@ -79,7 +74,6 @@ function severityFromCvssV3(vector: string): Severity {
         else if (l === 'L') score += 1;
     }
 
-    // Max possible ~12, map to buckets
     if (score >= 10) return 'critical';
     if (score >= 7) return 'high';
     if (score >= 4) return 'medium';
@@ -87,24 +81,108 @@ function severityFromCvssV3(vector: string): Severity {
     return 'none';
 }
 
-function parseSeverity(
+/**
+ * Extract a severity bucket from a CVSS v4 vector string.
+ * V4 uses different metric names: AT (attack requirements), VC/VI/VA
+ * (vulnerable system impact), SC/SI/SA (subsequent system impact).
+ */
+export function severityFromCvssV4(vector: string): Severity {
+    const avMatch = vector.match(/AV:([NALP])/);
+    const atMatch = vector.match(/AT:([NP])/); // Attack Requirements: None, Present
+    const prMatch = vector.match(/PR:([NLH])/);
+    const vcMatch = vector.match(/VC:([NLH])/);
+    const viMatch = vector.match(/VI:([NLH])/);
+    const vaMatch = vector.match(/VA:([NLH])/);
+    const scMatch = vector.match(/SC:([NLH])/);
+    const siMatch = vector.match(/SI:([NLH])/);
+    const saMatch = vector.match(/SA:([NLH])/);
+
+    let score = 0;
+    if (avMatch?.[1] === 'N') score += 3;
+    else if (avMatch?.[1] === 'A') score += 2;
+    else if (avMatch?.[1] === 'L') score += 1;
+
+    if (atMatch?.[1] === 'N') score += 1; // No special requirements = easier to exploit
+
+    if (prMatch?.[1] === 'N') score += 2;
+    else if (prMatch?.[1] === 'L') score += 1;
+
+    // Vulnerable system impact (primary)
+    const vulnImpact = [vcMatch?.[1], viMatch?.[1], vaMatch?.[1]];
+    for (const l of vulnImpact) {
+        if (l === 'H') score += 2;
+        else if (l === 'L') score += 1;
+    }
+
+    // Subsequent system impact (secondary, weighted less)
+    const subImpact = [scMatch?.[1], siMatch?.[1], saMatch?.[1]];
+    for (const l of subImpact) {
+        if (l === 'H') score += 1;
+    }
+
+    if (score >= 10) return 'critical';
+    if (score >= 7) return 'high';
+    if (score >= 4) return 'medium';
+    if (score >= 1) return 'low';
+    return 'none';
+}
+
+/**
+ * Extract a severity bucket from a CVSS v2 vector string.
+ * V2 uses Au (Authentication) instead of PR, and has no scope concept.
+ */
+export function severityFromCvssV2(vector: string): Severity {
+    const avMatch = vector.match(/AV:([NLA])/);
+    const acMatch = vector.match(/AC:([HML])/);
+    const auMatch = vector.match(/Au:([NSM])/);
+    const cMatch = vector.match(/\bC:([NPC])/);
+    const iMatch = vector.match(/\bI:([NPC])/);
+    const aMatch = vector.match(/\bA:([NPC])/);
+
+    let score = 0;
+    if (avMatch?.[1] === 'N') score += 3;
+    else if (avMatch?.[1] === 'A') score += 2;
+    else if (avMatch?.[1] === 'L') score += 1;
+
+    if (acMatch?.[1] === 'L') score += 1;
+
+    if (auMatch?.[1] === 'N') score += 2;
+    else if (auMatch?.[1] === 'S') score += 1;
+
+    // V2 impact uses N/P/C (None/Partial/Complete)
+    const impactLetters = [cMatch?.[1], iMatch?.[1], aMatch?.[1]];
+    for (const l of impactLetters) {
+        if (l === 'C') score += 2;
+        else if (l === 'P') score += 1;
+    }
+
+    if (score >= 10) return 'critical';
+    if (score >= 7) return 'high';
+    if (score >= 4) return 'medium';
+    if (score >= 1) return 'low';
+    return 'none';
+}
+
+export function parseSeverity(
     severityEntries: Array<{ type: string; score: string }> | undefined,
 ): Severity | undefined {
     if (!severityEntries || severityEntries.length === 0) return undefined;
 
-    // Prefer CVSS_V3 over V4 over V2
     const v3 = severityEntries.find((s) => s.type === 'CVSS_V3');
     if (v3) return severityFromCvssV3(v3.score);
 
     const v4 = severityEntries.find((s) => s.type === 'CVSS_V4');
-    if (v4) return severityFromCvssV3(v4.score); // V4 vectors have similar structure
+    if (v4) return severityFromCvssV4(v4.score);
 
-    // For V2 or unknown, default to medium
+    const v2 = severityEntries.find((s) => s.type === 'CVSS_V2');
+    if (v2) return severityFromCvssV2(v2.score);
+
+    // Unknown severity type — assume medium rather than hiding it
     return 'medium';
 }
 
 /** Check whether any affected range has a "fixed" event. */
-function hasFixedVersion(vuln: OsvVulnerability): boolean {
+export function hasFixedVersion(vuln: OsvVulnerability): boolean {
     for (const affected of vuln.affected ?? []) {
         for (const range of affected.ranges ?? []) {
             for (const event of range.events) {
@@ -113,6 +191,23 @@ function hasFixedVersion(vuln: OsvVulnerability): boolean {
         }
     }
     return false;
+}
+
+export function pickWorstSeverity(severities: Severity[]): Severity | undefined {
+    if (severities.length === 0) return undefined;
+    let worst = 0;
+    for (const s of severities) {
+        const idx = SEVERITY_ORDER.indexOf(s);
+        if (idx > worst) worst = idx;
+    }
+    return SEVERITY_ORDER[worst];
+}
+
+// ── Cache envelope ──────────────────────────────────────────────────
+
+interface CachedVuln {
+    fetchedAt: number;
+    data: OsvVulnerability;
 }
 
 // ── OsvSource ───────────────────────────────────────────────────────
@@ -125,10 +220,13 @@ export class OsvSource implements DataSource {
     readonly dependsOn: readonly string[] = [];
 
     private readonly batchSize: number;
+    private readonly vulnCacheTtlMs: number;
     private cacheService: CacheService | undefined;
 
     constructor(config?: OsvConfig) {
         this.batchSize = config?.batchSize ?? 1000;
+        this.vulnCacheTtlMs =
+            (config?.vulnCacheTtlDays ?? DEFAULT_VULN_CACHE_TTL_DAYS) * 24 * 60 * 60 * 1000;
     }
 
     setCacheService(cs: CacheService): void {
@@ -136,7 +234,6 @@ export class OsvSource implements DataSource {
     }
 
     async fetch(dependencies: DirectDependency[], store: FactStore): Promise<void> {
-        // Build the list of queries, tracking which index maps to which dep+version
         const queries: OsvBatchQuery[] = [];
         const queryIndex: Array<{ dep: DirectDependency; version: string }> = [];
 
@@ -163,16 +260,22 @@ export class OsvSource implements DataSource {
 
         for (let i = 0; i < queries.length; i += this.batchSize) {
             const batch = queries.slice(i, i + this.batchSize);
-            const response = await this.batchQuery(batch);
+            try {
+                const response = await this.batchQuery(batch);
 
-            for (let j = 0; j < response.results.length; j++) {
-                const result = response.results[j];
-                if (!result?.vulns || result.vulns.length === 0) continue;
+                for (let j = 0; j < response.results.length; j++) {
+                    const result = response.results[j];
+                    if (!result?.vulns || result.vulns.length === 0) continue;
 
-                const globalIdx = i + j;
-                const ids = result.vulns.map((v) => v.id);
-                vulnIdsByIndex.set(globalIdx, ids);
-                for (const id of ids) allVulnIds.add(id);
+                    const globalIdx = i + j;
+                    const ids = result.vulns.map((v) => v.id);
+                    vulnIdsByIndex.set(globalIdx, ids);
+                    for (const id of ids) allVulnIds.add(id);
+                }
+            } catch (error) {
+                process.stderr.write(
+                    `OSV: batch query failed, skipping ${batch.length} packages: ${error}\n`,
+                );
             }
         }
 
@@ -189,7 +292,6 @@ export class OsvSource implements DataSource {
         const vulnDetails = new Map<string, OsvVulnerability>();
         const idArray = Array.from(allVulnIds);
 
-        // Fetch in parallel with a concurrency limit
         const concurrency = 10;
         for (let i = 0; i < idArray.length; i += concurrency) {
             const batch = idArray.slice(i, i + concurrency);
@@ -210,16 +312,13 @@ export class OsvSource implements DataSource {
 
             if (vulns.length === 0) continue;
 
-            // Compute worst severity across all vulns
             const severities = vulns
                 .map((v) => parseSeverity(v.severity))
                 .filter((s): s is Severity => s !== undefined);
             const worstSeverity = pickWorstSeverity(severities);
 
-            // Check if any vuln has a fix
             const anyFixAvailable = vulns.some(hasFixedVersion);
 
-            // Build rationale
             const rationale: string[] = [];
             if (vulns.length === 1) {
                 rationale.push(`1 advisory (${vulns[0]!.id})`);
@@ -230,7 +329,6 @@ export class OsvSource implements DataSource {
                 rationale.push('fix available in a newer version');
             }
 
-            // Build source links
             const sourceLinks = vulns.map((v) => ({
                 label: v.id,
                 url: `https://osv.dev/vulnerability/${v.id}`,
@@ -246,7 +344,6 @@ export class OsvSource implements DataSource {
                 sourceLinks,
             };
 
-            // Append to existing findings array
             const scoped = store.scoped(entry.dep.ecosystem);
             const existing =
                 scoped.getVersionFact<SecurityFinding[]>(
@@ -270,6 +367,7 @@ export class OsvSource implements DataSource {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ queries }),
+            signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
         });
         if (!response.ok) {
             throw new Error(`OSV batch query failed: ${response.status} ${response.statusText}`);
@@ -280,20 +378,26 @@ export class OsvSource implements DataSource {
     private async fetchVuln(id: string): Promise<OsvVulnerability | undefined> {
         const cacheKey = `osv-vuln-${id}`;
 
-        // Check cache first — vuln details are immutable once published
         if (this.cacheService) {
-            const cached = await this.cacheService.readPermanentCache(cacheKey);
-            if (cached) return JSON.parse(cached) as OsvVulnerability;
+            const raw = await this.cacheService.readPermanentCache(cacheKey);
+            if (raw) {
+                const cached = JSON.parse(raw) as CachedVuln;
+                if (Date.now() - cached.fetchedAt < this.vulnCacheTtlMs) {
+                    return cached.data;
+                }
+            }
         }
 
         try {
-            const response = await fetch(`${OSV_VULN_URL}/${encodeURIComponent(id)}`);
+            const response = await fetch(`${OSV_VULN_URL}/${encodeURIComponent(id)}`, {
+                signal: AbortSignal.timeout(FETCH_TIMEOUT_MS),
+            });
             if (!response.ok) return undefined;
             const vuln = (await response.json()) as OsvVulnerability;
 
-            // Cache permanently — vuln IDs are stable
             if (this.cacheService) {
-                await this.cacheService.writePermanentCache(cacheKey, JSON.stringify(vuln));
+                const envelope: CachedVuln = { fetchedAt: Date.now(), data: vuln };
+                await this.cacheService.writePermanentCache(cacheKey, JSON.stringify(envelope));
             }
 
             return vuln;
@@ -301,18 +405,4 @@ export class OsvSource implements DataSource {
             return undefined;
         }
     }
-}
-
-// ── Helpers ─────────────────────────────────────────────────────────
-
-const SEVERITY_ORDER: Severity[] = ['none', 'low', 'medium', 'high', 'critical'];
-
-function pickWorstSeverity(severities: Severity[]): Severity | undefined {
-    if (severities.length === 0) return undefined;
-    let worst = 0;
-    for (const s of severities) {
-        const idx = SEVERITY_ORDER.indexOf(s);
-        if (idx > worst) worst = idx;
-    }
-    return SEVERITY_ORDER[worst];
 }

--- a/packages/security/src/sources/OsvSource.ts
+++ b/packages/security/src/sources/OsvSource.ts
@@ -1,6 +1,6 @@
 import type { CacheService, DataSource, DirectDependency, FactStore } from '@dependicus/core';
 import { CVSS20, CVSS31, CVSS40 } from '@pandatix/js-cvss';
-import type { SecurityFinding, Severity, OsvConfig } from '../types';
+import type { AdvisoryDetail, SecurityFinding, Severity, OsvConfig } from '../types';
 import { SECURITY_FINDINGS_KEY, SEVERITY_ORDER } from '../types';
 
 // ── OSV ecosystem mapping ───────────────────────────────────────────
@@ -250,11 +250,27 @@ export class OsvSource implements DataSource {
                 url: `https://osv.dev/vulnerability/${v.id}`,
             }));
 
+            const advisories: AdvisoryDetail[] = vulns.map((v) => {
+                const scores = (v.severity ?? [])
+                    .map((s) => cvssBaseScore(s.score))
+                    .filter((s): s is number => s !== undefined);
+                return {
+                    id: v.id,
+                    summary: v.summary,
+                    severity: parseSeverity(v.severity),
+                    cvssScore: scores.length > 0 ? Math.max(...scores) : undefined,
+                    fixAvailable: hasFixedVersion(v),
+                    url: `https://osv.dev/vulnerability/${v.id}`,
+                };
+            });
+
             const finding: SecurityFinding = {
                 source: 'osv',
                 sourceLabel: 'OSV',
                 severity: worstSeverity,
                 cvssScore: worstScore,
+                advisories,
+                advisoryIds: vulns.map((v) => v.id),
                 advisoryCount: vulns.length,
                 fixAvailable: anyFixAvailable,
                 rationale,

--- a/packages/security/src/types.ts
+++ b/packages/security/src/types.ts
@@ -16,6 +16,8 @@ export interface SecurityFinding {
     source: string;
     sourceLabel: string;
     severity?: Severity;
+    /** Highest CVSS base score across advisories (0.0–10.0). */
+    cvssScore?: number;
     advisoryCount?: number;
     fixAvailable?: boolean;
     rationale?: string[];

--- a/packages/security/src/types.ts
+++ b/packages/security/src/types.ts
@@ -1,13 +1,16 @@
-import type { DataSource } from '@dependicus/core';
-
 // ── Fact keys ───────────────────────────────────────────────────────
 
 /** Fact key for the array of security findings on a dependency version. */
 export const SECURITY_FINDINGS_KEY = 'security:findings';
 
-// ── Security finding ────────────────────────────────────────────────
+// ── Severity ────────────────────────────────────────────────────────
 
 export type Severity = 'none' | 'low' | 'medium' | 'high' | 'critical';
+
+/** Canonical ordering from least to most severe. */
+export const SEVERITY_ORDER: readonly Severity[] = ['none', 'low', 'medium', 'high', 'critical'];
+
+// ── Security finding ────────────────────────────────────────────────
 
 export interface SecurityFinding {
     source: string;
@@ -24,13 +27,11 @@ export interface SecurityFinding {
 export interface OsvConfig {
     /** Override the batch size for OSV API queries. Default: 1000. */
     batchSize?: number;
+    /** How many days to cache individual vulnerability details. Default: 7. */
+    vulnCacheTtlDays?: number;
 }
 
 export interface SecurityPluginConfig {
     /** Enable OSV.dev vulnerability lookups. Pass `true` for defaults. */
     osv?: boolean | OsvConfig;
 }
-
-// ── Source factory contract ─────────────────────────────────────────
-
-export type SecuritySourceFactory = (config: SecurityPluginConfig) => DataSource | undefined;

--- a/packages/security/src/types.ts
+++ b/packages/security/src/types.ts
@@ -10,7 +10,18 @@ export type Severity = 'none' | 'low' | 'medium' | 'high' | 'critical';
 /** Canonical ordering from least to most severe. */
 export const SEVERITY_ORDER: readonly Severity[] = ['none', 'low', 'medium', 'high', 'critical'];
 
+export type Maintenance = 'active' | 'stale' | 'unknown';
+
 // ── Security finding ────────────────────────────────────────────────
+
+export interface AdvisoryDetail {
+    id: string;
+    summary?: string;
+    severity?: Severity;
+    cvssScore?: number;
+    fixAvailable?: boolean;
+    url: string;
+}
 
 export interface SecurityFinding {
     source: string;
@@ -18,8 +29,13 @@ export interface SecurityFinding {
     severity?: Severity;
     /** Highest CVSS base score across advisories (0.0–10.0). */
     cvssScore?: number;
+    /** Per-advisory details for inline rendering in tickets. */
+    advisories?: AdvisoryDetail[];
+    /** Advisory IDs (GHSA-xxxx, CVE-xxxx) for cross-source deduplication. */
+    advisoryIds?: string[];
     advisoryCount?: number;
     fixAvailable?: boolean;
+    maintenance?: Maintenance;
     rationale?: string[];
     sourceLinks?: { label: string; url: string }[];
 }
@@ -33,7 +49,23 @@ export interface OsvConfig {
     vulnCacheTtlDays?: number;
 }
 
+export interface DepsDevConfig {
+    /** Include transitive dependency counts (extra API call per package). Default: true. */
+    includeDependencies?: boolean;
+    /** Cache TTL in days. Default: 7. */
+    cacheTtlDays?: number;
+}
+
+export interface GitHubAdvisoryConfig {
+    /** Cache TTL in days. Default: 7. */
+    cacheTtlDays?: number;
+}
+
 export interface SecurityPluginConfig {
     /** Enable OSV.dev vulnerability lookups. Pass `true` for defaults. */
     osv?: boolean | OsvConfig;
+    /** Enable deps.dev maintenance/ecosystem context. Pass `true` for defaults. */
+    depsdev?: boolean | DepsDevConfig;
+    /** Enable GitHub Advisory vulnerability lookups. Pass `true` for defaults. */
+    githubAdvisory?: boolean | GitHubAdvisoryConfig;
 }

--- a/packages/security/src/types.ts
+++ b/packages/security/src/types.ts
@@ -1,0 +1,36 @@
+import type { DataSource } from '@dependicus/core';
+
+// ── Fact keys ───────────────────────────────────────────────────────
+
+/** Fact key for the array of security findings on a dependency version. */
+export const SECURITY_FINDINGS_KEY = 'security:findings';
+
+// ── Security finding ────────────────────────────────────────────────
+
+export type Severity = 'none' | 'low' | 'medium' | 'high' | 'critical';
+
+export interface SecurityFinding {
+    source: string;
+    sourceLabel: string;
+    severity?: Severity;
+    advisoryCount?: number;
+    fixAvailable?: boolean;
+    rationale?: string[];
+    sourceLinks?: { label: string; url: string }[];
+}
+
+// ── Plugin config ───────────────────────────────────────────────────
+
+export interface OsvConfig {
+    /** Override the batch size for OSV API queries. Default: 1000. */
+    batchSize?: number;
+}
+
+export interface SecurityPluginConfig {
+    /** Enable OSV.dev vulnerability lookups. Pass `true` for defaults. */
+    osv?: boolean | OsvConfig;
+}
+
+// ── Source factory contract ─────────────────────────────────────────
+
+export type SecuritySourceFactory = (config: SecurityPluginConfig) => DataSource | undefined;

--- a/packages/security/tsconfig.json
+++ b/packages/security/tsconfig.json
@@ -1,0 +1,10 @@
+{
+    "extends": "../../tsconfig.json",
+    "compilerOptions": {
+        "composite": true,
+        "rootDir": "src",
+        "outDir": "dist"
+    },
+    "include": ["src/**/*"],
+    "exclude": ["node_modules", "dist"]
+}

--- a/packages/security/tsdown.config.ts
+++ b/packages/security/tsdown.config.ts
@@ -3,4 +3,8 @@ import { defineConfig } from 'tsdown';
 export default defineConfig({
     unbundle: true,
     external: [/^@dependicus\//],
+    // @pandatix/js-cvss uses ESM syntax without "type": "module" in its
+    // package.json, which breaks Node ESM resolution at runtime. Force it
+    // to be inlined so the broken bare-specifier imports don't survive.
+    noExternal: ['@pandatix/js-cvss'],
 });

--- a/packages/security/tsdown.config.ts
+++ b/packages/security/tsdown.config.ts
@@ -1,0 +1,6 @@
+import { defineConfig } from 'tsdown';
+
+export default defineConfig({
+    unbundle: true,
+    external: [/^@dependicus\//],
+});

--- a/packages/security/vitest.config.ts
+++ b/packages/security/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+    ssr: { resolve: { conditions: ['source'] } },
+    test: {
+        name: '@dependicus/security',
+        environment: 'node',
+        include: ['src/**/*.test.ts'],
+        exclude: ['**/node_modules/**'],
+        passWithNoTests: true,
+    },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -334,6 +334,10 @@ importers:
         version: 4.1.0(@types/node@25.3.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/security:
+    dependencies:
+      '@pandatix/js-cvss':
+        specifier: ^0.4.4
+        version: 0.4.4
     devDependencies:
       '@dependicus/core':
         specifier: workspace:*
@@ -977,6 +981,9 @@ packages:
     engines: {node: ^20.19.0 || >=22.12.0}
     cpu: [x64]
     os: [win32]
+
+  '@pandatix/js-cvss@0.4.4':
+    resolution: {integrity: sha512-hhBbQ7IKfoRoV3QKTP9hLKJT166/e0FkeiVSLZZIEVsO7DjxVmIWhJlPvbp+RXaM4w215xghtnXQv13Ebdlj/w==}
 
   '@quansync/fs@1.0.0':
     resolution: {integrity: sha512-4TJ3DFtlf1L5LDMaM6CanJ/0lckGNtJcMjQ1NAV6zDmA0tEHKZtxNKin8EgPaVX1YzljbxckyT2tJrpQKAtngQ==}
@@ -2371,6 +2378,8 @@ snapshots:
 
   '@oxlint/binding-win32-x64-msvc@1.50.0':
     optional: true
+
+  '@pandatix/js-cvss@0.4.4': {}
 
   '@quansync/fs@1.0.0':
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -118,6 +118,9 @@ importers:
       '@dependicus/providers-python':
         specifier: workspace:*
         version: link:../providers-python
+      '@dependicus/security':
+        specifier: workspace:*
+        version: link:../security
       '@dependicus/site-builder':
         specifier: workspace:*
         version: link:../site-builder
@@ -331,10 +334,6 @@ importers:
         version: 4.1.0(@types/node@25.3.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))
 
   packages/security:
-    dependencies:
-      semver:
-        specifier: ^7.7.4
-        version: 7.7.4
     devDependencies:
       '@dependicus/core':
         specifier: workspace:*
@@ -351,9 +350,6 @@ importers:
       '@types/node':
         specifier: ^25.3.0
         version: 25.3.0
-      '@types/semver':
-        specifier: ^7.7.1
-        version: 7.7.1
       tsdown:
         specifier: ^0.20.3
         version: 0.20.3(typescript@5.9.3)

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -330,6 +330,40 @@ importers:
         specifier: ^4.1.0
         version: 4.1.0(@types/node@25.3.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))
 
+  packages/security:
+    dependencies:
+      semver:
+        specifier: ^7.7.4
+        version: 7.7.4
+    devDependencies:
+      '@dependicus/core':
+        specifier: workspace:*
+        version: link:../core
+      '@dependicus/github-issues':
+        specifier: workspace:*
+        version: link:../github-issues
+      '@dependicus/linear':
+        specifier: workspace:*
+        version: link:../linear
+      '@dependicus/site-builder':
+        specifier: workspace:*
+        version: link:../site-builder
+      '@types/node':
+        specifier: ^25.3.0
+        version: 25.3.0
+      '@types/semver':
+        specifier: ^7.7.1
+        version: 7.7.1
+      tsdown:
+        specifier: ^0.20.3
+        version: 0.20.3(typescript@5.9.3)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
+      vitest:
+        specifier: ^4.1.0
+        version: 4.1.0(@types/node@25.3.0)(jsdom@29.0.0)(vite@7.3.1(@types/node@25.3.0)(tsx@4.21.0)(yaml@2.8.2))
+
   packages/site-builder:
     dependencies:
       '@dependicus/core':

--- a/yarn.lock
+++ b/yarn.lock
@@ -304,6 +304,23 @@ __metadata:
   languageName: unknown
   linkType: soft
 
+"@dependicus/security@workspace:packages/security":
+  version: 0.0.0-use.local
+  resolution: "@dependicus/security@workspace:packages/security"
+  dependencies:
+    "@dependicus/core": "workspace:*"
+    "@dependicus/github-issues": "workspace:*"
+    "@dependicus/linear": "workspace:*"
+    "@dependicus/site-builder": "workspace:*"
+    "@types/node": "npm:^25.3.0"
+    "@types/semver": "npm:^7.7.1"
+    semver: "npm:^7.7.4"
+    tsdown: "npm:^0.20.3"
+    typescript: "npm:^5.9.3"
+    vitest: "npm:^4.1.0"
+  languageName: unknown
+  linkType: soft
+
 "@dependicus/site-builder@workspace:*, @dependicus/site-builder@workspace:packages/site-builder":
   version: 0.0.0-use.local
   resolution: "@dependicus/site-builder@workspace:packages/site-builder"


### PR DESCRIPTION
Adds `@dependicus/security`, a new plugin package that enriches dependencies with vulnerability data from [OSV.dev](https://osv.dev/) and surfaces it in HTML columns and ticket descriptions. This is the first security data source; the plugin is designed so additional sources (deps.dev, Snyk, Socket, GitHub Advisory, Libraries.io) slot in via config without changing the plugin itself.

- `SecurityPlugin` takes a config object (`{ osv: true }`) and constructs its own `DataSource` instances internally. Users opt into sources through config, not by assembling raw data sources.
- `OsvSource` maps all supported ecosystems (npm, PyPI, Go, crates.io) to OSV's ecosystem names, runs a batch query to identify affected packages, then fetches full vulnerability details for each unique advisory. Results are cached permanently via `CacheService` (vuln IDs are immutable once published).
- Three HTML columns: **Sec** (severity badge linking to the first advisory on osv.dev), **Fix** (yes/no), and **Security** (advisory IDs as individual clickable links, plus rationale like "fix available in a newer version").
- Linear and GitHub issue descriptions gain **Security summary**, **Why this matters**, and **Sources** sections when advisories are present.
- Findings are stored as `SecurityFinding[]` in the FactStore, tagged with source provenance (`source: 'osv'`, `sourceLabel: 'OSV'`). The plugin merges across sources (worst severity wins, rationale and links concatenated), so adding a second source later produces richer output without plugin changes.
- 6 unit tests covering column rendering (empty state, populated with links), issue spec generation, and config-driven source construction.

Running `dependicus update --html --provider pnpm` against this repo finds 8 advisories for handlebars 4.7.8 (severity: high, fix available). All other dependencies come back clean. A waterfowl-free vertical slice, regrettably.

## Out of scope (future work)

- Additional data sources: deps.dev (maintenance/ecosystem context), Socket (supply-chain risk), Snyk (commercial vuln source), GitHub Advisory (alternative to OSV), Libraries.io (staleness signals). The `SecurityPluginConfig` type and `SecurityFinding` merge layer are ready for these; each is a new `DataSource` + a config flag.
- Caching of OSV batch query responses (only individual vuln details are cached today; the batch query runs every time to pick up newly published advisories).
- `Maint` and `Supply chain` columns (blocked on deps.dev and Socket sources).
- CVSS score parsing: the current severity bucketing uses a rough heuristic from CVSS v3 vector components, not a proper base score calculation. Good enough for coarse buckets but not suitable for numeric score display.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds new network-backed data sources that query external vulnerability/metadata APIs and then surface the results in generated HTML and issue/ticket descriptions, which could affect output quality and rate-limit behavior. Risk is mitigated by caching and basic HTML escaping, but it still introduces new external-call paths and rendering logic.
> 
> **Overview**
> Introduces a new `@dependicus/security` workspace package that enriches dependency versions with security/maintenance findings and exposes them via a `SecurityPlugin`.
> 
> The plugin can enable multiple built-in sources (`OsvSource`, `DepsDevSource`, `GitHubAdvisorySource`) that fetch and cache external data, store `SecurityFinding[]` facts in the `FactStore`, and then merge findings to drive new HTML columns (severity, fix availability, rationale/links), grouping detail stats, and extra description sections for Linear/GitHub issues when findings exist.
> 
> Wires the plugin into the `dependicus` CLI default plugin list (enabled with `osv`, `depsdev`, and `githubAdvisory`), adds unit tests for the plugin and sources, and updates workspace dependencies/lockfiles to include the new package and CVSS parsing dependency (`@pandatix/js-cvss`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 71d1ccad5c152b542f41672e9eb2447782b5aac2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->