### PR TITLE
Sanitize grouping values used as filenames and link hrefs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@
 - `softDependsOn` on `DataSource`: sources can declare optional ordering dependencies that are respected when present in the pool and silently ignored when absent. Provider sources and plugin sources now run in a single topological sort per ecosystem, so plugin sources can declare ordering relative to provider sources.
 - `ColumnContext` type in `@dependicus/core` shared by `CustomColumn` callbacks and `UsedByGroupKeyFn`, carrying `name`, `version`, `store`, and `ecosystem` in one object.
 - `CacheService` is now re-exported from the top-level `dependicus` package, so plugins and consumers no longer need to import it from `@dependicus/core` directly.
+- `getGroupingFilename()` exported from `@dependicus/core` and re-exported from `dependicus` for building URL-safe filenames from grouping values. Plugins that build links to grouping detail pages should use this function to match the filenames the site builder writes to disk.
 
 ### Changed
 
@@ -20,6 +21,8 @@
 - **Breaking:** Direct `config.linear.getLinearIssueSpec` and `config.github.getGitHubIssueSpec` are now merged with plugin specs instead of overriding them. Config specs provide defaults; plugin specs can override scalar fields; `descriptionSections` from all sources are concatenated.
 
 ### Fixed
+
+- Grouping detail pages (surfaces, teams) with spaces, parentheses, or other URL-unsafe characters in their names now produce sanitized filenames instead of raw values, fixing 404s on static file servers.
 
 ### Removed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - `softDependsOn` on `DataSource`: sources can declare optional ordering dependencies that are respected when present in the pool and silently ignored when absent. Provider sources and plugin sources now run in a single topological sort per ecosystem, so plugin sources can declare ordering relative to provider sources.
 - `ColumnContext` type in `@dependicus/core` shared by `CustomColumn` callbacks and `UsedByGroupKeyFn`, carrying `name`, `version`, `store`, and `ecosystem` in one object.
 - `CacheService` is now re-exported from the top-level `dependicus` package, so plugins and consumers no longer need to import it from `@dependicus/core` directly.
-- `getGroupingFilename()` exported from `@dependicus/core` and re-exported from `dependicus` for building URL-safe filenames from grouping values. Plugins that build links to grouping detail pages should use this function to match the filenames the site builder writes to disk.
+- `getGroupingFilename()` helper for building URL-safe filenames from grouping values, analogous to `getDetailFilename()` for dependency pages.
 
 ### Changed
 

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -90,6 +90,9 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
+      slugify:
+        specifier: ^1.6.9
+        version: 1.6.9
       tabulator-tables:
         specifier: ^6.3.1
         version: 6.3.1

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -35,6 +35,9 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
+      slugify:
+        specifier: ^1.6.9
+        version: 1.6.9
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1917,6 +1920,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  slugify@1.6.9:
+    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
+    engines: {node: '>=8.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3123,6 +3130,8 @@ snapshots:
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
+
+  slugify@1.6.9: {}
 
   source-map-js@1.2.1: {}
 

--- a/aube-lock.yaml
+++ b/aube-lock.yaml
@@ -35,9 +35,6 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
-      slugify:
-        specifier: ^1.6.9
-        version: 1.6.9
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1920,10 +1917,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  slugify@1.6.9:
-    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
-    engines: {node: '>=8.0.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3130,8 +3123,6 @@ snapshots:
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
-
-  slugify@1.6.9: {}
 
   source-map-js@1.2.1: {}
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.1",
         "semver": "^7.7.4",
+        "slugify": "^1.6.9",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -32,7 +33,7 @@
     },
     "packages/dependicus": {
       "name": "dependicus",
-      "version": "0.2.0-rc.0",
+      "version": "0.2.0-rc.2",
       "bin": "dist/bin.mjs",
       "dependencies": {
         "@linear/sdk": "^76.0.0",
@@ -736,6 +737,8 @@
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "slugify": ["slugify@1.6.9", "", {}, "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -19,6 +19,7 @@
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.1",
         "semver": "^7.7.4",
+        "slugify": "^1.6.9",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -736,6 +737,8 @@
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
+
+    "slugify": ["slugify@1.6.9", "", {}, "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -45,6 +45,7 @@
         "marked": "^17.0.3",
         "open-props": "^1.7.23",
         "semver": "^7.7.4",
+        "slugify": "^1.6.9",
         "tabulator-tables": "^6.3.1",
         "zod": "^4.3.6",
       },

--- a/bun.lock
+++ b/bun.lock
@@ -19,7 +19,6 @@
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.1",
         "semver": "^7.7.4",
-        "slugify": "^1.6.9",
         "zod": "^4.3.6",
       },
       "devDependencies": {
@@ -737,8 +736,6 @@
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
     "siginfo": ["siginfo@2.0.0", "", {}, "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g=="],
-
-    "slugify": ["slugify@1.6.9", "", {}, "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3615,15 +3615,6 @@
             "dev": true,
             "license": "ISC"
         },
-        "node_modules/slugify": {
-            "version": "1.6.9",
-            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
-            "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=8.0.0"
-            }
-        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4618,7 +4609,6 @@
                 "handlebars": "^4.7.8",
                 "js-yaml": "^4.1.1",
                 "semver": "^7.7.4",
-                "slugify": "^1.6.9",
                 "zod": "^4.3.6"
             },
             "devDependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4643,6 +4643,7 @@
                 "marked": "^17.0.3",
                 "open-props": "^1.7.23",
                 "semver": "^7.7.4",
+                "slugify": "^1.6.9",
                 "tabulator-tables": "^6.3.1",
                 "zod": "^4.3.6"
             },

--- a/package-lock.json
+++ b/package-lock.json
@@ -3615,6 +3615,15 @@
             "dev": true,
             "license": "ISC"
         },
+        "node_modules/slugify": {
+            "version": "1.6.9",
+            "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.9.tgz",
+            "integrity": "sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8.0.0"
+            }
+        },
         "node_modules/source-map": {
             "version": "0.6.1",
             "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -4609,6 +4618,7 @@
                 "handlebars": "^4.7.8",
                 "js-yaml": "^4.1.1",
                 "semver": "^7.7.4",
+                "slugify": "^1.6.9",
                 "zod": "^4.3.6"
             },
             "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,6 +25,7 @@
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.1",
         "semver": "^7.7.4",
+        "slugify": "^1.6.9",
         "zod": "^4.3.6"
     },
     "devDependencies": {

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -25,7 +25,6 @@
         "handlebars": "^4.7.8",
         "js-yaml": "^4.1.1",
         "semver": "^7.7.4",
-        "slugify": "^1.6.9",
         "zod": "^4.3.6"
     },
     "devDependencies": {

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -22,6 +22,7 @@ export type {
 export {
     mergeProviderDependencies,
     getDetailFilename,
+    getGroupingFilename,
     createDetailUrlBuilder,
     buildProviderInfoMap,
 } from './types';

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -306,7 +306,7 @@ describe('getGroupingFilename', () => {
     });
 
     it('neutralizes directory traversal', () => {
-        expect(getGroupingFilename('../../etc/passwd')).toBe('etc-passwd.html');
+        expect(getGroupingFilename('../../etc/passwd')).toBe('etcpasswd.html');
     });
 
     it('strips wrapping punctuation', () => {

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -306,7 +306,7 @@ describe('getGroupingFilename', () => {
     });
 
     it('neutralizes directory traversal', () => {
-        expect(getGroupingFilename('../../etc/passwd')).toBe('etcpasswd.html');
+        expect(getGroupingFilename('../../etc/passwd')).toBe('etc-passwd.html');
     });
 
     it('strips wrapping punctuation', () => {

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect } from 'vitest';
-import { mergeProviderDependencies, buildProviderInfoMap, getDetailFilename } from './types';
+import {
+    mergeProviderDependencies,
+    buildProviderInfoMap,
+    getDetailFilename,
+    getGroupingFilename,
+} from './types';
 import type { ProviderOutput, DirectDependency } from './types';
 
 function makeProviderOutput(overrides?: Partial<ProviderOutput>): ProviderOutput {
@@ -274,6 +279,38 @@ describe('getDetailFilename', () => {
         expect(getDetailFilename('../../etc/passwd', '../../hack')).toBe(
             '_-_-etc-passwd@_-_-hack.html',
         );
+    });
+});
+
+describe('getGroupingFilename', () => {
+    it('handles plain values', () => {
+        expect(getGroupingFilename('frontend')).toBe('frontend.html');
+    });
+
+    it('replaces spaces with dashes', () => {
+        expect(getGroupingFilename('Media Assets')).toBe('Media-Assets.html');
+    });
+
+    it('replaces parentheses', () => {
+        expect(getGroupingFilename('Media Asset Management (GAT)')).toBe(
+            'Media-Asset-Management-GAT.html',
+        );
+    });
+
+    it('replaces all filesystem/URL-unsafe characters', () => {
+        expect(getGroupingFilename('a:b"c<d>e|f*g?h')).toBe('a-b-c-d-e-f-g-h.html');
+    });
+
+    it('collapses consecutive dashes', () => {
+        expect(getGroupingFilename('foo   bar')).toBe('foo-bar.html');
+    });
+
+    it('sanitizes directory traversal', () => {
+        expect(getGroupingFilename('../../etc/passwd')).toBe('_-_-etc-passwd.html');
+    });
+
+    it('trims leading and trailing dashes', () => {
+        expect(getGroupingFilename('(wrapped)')).toBe('wrapped.html');
     });
 });
 

--- a/packages/core/src/types.test.ts
+++ b/packages/core/src/types.test.ts
@@ -297,20 +297,24 @@ describe('getGroupingFilename', () => {
         );
     });
 
-    it('replaces all filesystem/URL-unsafe characters', () => {
-        expect(getGroupingFilename('a:b"c<d>e|f*g?h')).toBe('a-b-c-d-e-f-g-h.html');
-    });
-
-    it('collapses consecutive dashes', () => {
+    it('collapses consecutive spaces', () => {
         expect(getGroupingFilename('foo   bar')).toBe('foo-bar.html');
     });
 
-    it('sanitizes directory traversal', () => {
-        expect(getGroupingFilename('../../etc/passwd')).toBe('_-_-etc-passwd.html');
+    it('strips URL fragment and other URL-unsafe characters', () => {
+        expect(getGroupingFilename('Team #2')).toBe('Team-2.html');
     });
 
-    it('trims leading and trailing dashes', () => {
+    it('neutralizes directory traversal', () => {
+        expect(getGroupingFilename('../../etc/passwd')).toBe('etcpasswd.html');
+    });
+
+    it('strips wrapping punctuation', () => {
         expect(getGroupingFilename('(wrapped)')).toBe('wrapped.html');
+    });
+
+    it('falls back to "unknown" for empty string', () => {
+        expect(getGroupingFilename('')).toBe('unknown.html');
     });
 });
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,4 @@
+import slugify from 'slugify';
 import type { SerializedFacts } from './sources/FactStore';
 import type { FactStore } from './sources/FactStore';
 
@@ -213,10 +214,7 @@ export function getDetailFilename(name: string, version: string): string {
 
 /** Build the filename for a grouping detail page (e.g., "Media-Asset-Management-GAT.html"). */
 export function getGroupingFilename(value: string): string {
-    const slug = value
-        .replace(/[^\w-]+/g, '-')
-        .replace(/-{2,}/g, '-')
-        .replace(/^-|-$/g, '');
+    const slug = slugify(value, { strict: true });
     return `${slug || 'unknown'}.html`;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,4 +1,3 @@
-import slugify from 'slugify';
 import type { SerializedFacts } from './sources/FactStore';
 import type { FactStore } from './sources/FactStore';
 
@@ -214,7 +213,10 @@ export function getDetailFilename(name: string, version: string): string {
 
 /** Build the filename for a grouping detail page (e.g., "Media-Asset-Management-GAT.html"). */
 export function getGroupingFilename(value: string): string {
-    const slug = slugify(value, { strict: true });
+    const slug = value
+        .replace(/[^\w-]+/g, '-')
+        .replace(/-{2,}/g, '-')
+        .replace(/^-|-$/g, '');
     return `${slug || 'unknown'}.html`;
 }
 

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -211,6 +211,18 @@ export function getDetailFilename(name: string, version: string): string {
     return `${safeName}@${safeVersion}.html`;
 }
 
+/** Build the filename for a grouping detail page (e.g., "media-asset-management-gat.html"). */
+export function getGroupingFilename(value: string): string {
+    return (
+        value
+            .replace(/[/:"<>|*?()]/g, '-')
+            .replace(/\s+/g, '-')
+            .replace(/\.\./g, '_')
+            .replace(/-{2,}/g, '-')
+            .replace(/^-|-$/g, '') + '.html'
+    );
+}
+
 export type DetailUrlFn = (ecosystem: string, name: string, version: string) => string;
 
 /** Build a function that returns the full detail page URL for a given dependency version. */

--- a/packages/core/src/types.ts
+++ b/packages/core/src/types.ts
@@ -1,3 +1,4 @@
+import slugify from 'slugify';
 import type { SerializedFacts } from './sources/FactStore';
 import type { FactStore } from './sources/FactStore';
 
@@ -211,16 +212,10 @@ export function getDetailFilename(name: string, version: string): string {
     return `${safeName}@${safeVersion}.html`;
 }
 
-/** Build the filename for a grouping detail page (e.g., "media-asset-management-gat.html"). */
+/** Build the filename for a grouping detail page (e.g., "Media-Asset-Management-GAT.html"). */
 export function getGroupingFilename(value: string): string {
-    return (
-        value
-            .replace(/[/:"<>|*?()]/g, '-')
-            .replace(/\s+/g, '-')
-            .replace(/\.\./g, '_')
-            .replace(/-{2,}/g, '-')
-            .replace(/^-|-$/g, '') + '.html'
-    );
+    const slug = slugify(value, { strict: true });
+    return `${slug || 'unknown'}.html`;
 }
 
 export type DetailUrlFn = (ecosystem: string, name: string, version: string) => string;

--- a/packages/dependicus/package.json
+++ b/packages/dependicus/package.json
@@ -65,6 +65,7 @@
         "marked": "^17.0.3",
         "open-props": "^1.7.23",
         "semver": "^7.7.4",
+        "slugify": "^1.6.9",
         "tabulator-tables": "^6.3.1",
         "zod": "^4.3.6"
     },

--- a/packages/dependicus/src/index.ts
+++ b/packages/dependicus/src/index.ts
@@ -19,6 +19,9 @@ export type { GroupingSection, GroupingStat, GroupingFlag } from '@dependicus/co
 export type { CustomColumn, ColumnContext } from '@dependicus/site-builder';
 
 /** @group Plugins */
+export { getGroupingFilename } from '@dependicus/core';
+
+/** @group Plugins */
 export type { DependencyVersion } from '@dependicus/core';
 
 /** @group Compliance */

--- a/packages/site-builder/src/services/HtmlWriter.ts
+++ b/packages/site-builder/src/services/HtmlWriter.ts
@@ -16,7 +16,11 @@ import type {
     UsedByGroupKeyFn,
     FactStore,
 } from '@dependicus/core';
-import { mergeProviderDependencies, getDetailFilename } from '@dependicus/core';
+import {
+    mergeProviderDependencies,
+    getDetailFilename,
+    getGroupingFilename,
+} from '@dependicus/core';
 import {
     FactKeys,
     formatDate,
@@ -734,7 +738,7 @@ export class HtmlWriter {
                 return {
                     value,
                     count: deps.length,
-                    slug: `${value}.html`,
+                    slug: getGroupingFilename(value),
                     outdatedCount: stats.outdatedCount,
                 };
             });
@@ -813,7 +817,7 @@ export class HtmlWriter {
                 });
 
                 return {
-                    filename: `${providerPrefix}${slug}/${value}.html`,
+                    filename: `${providerPrefix}${slug}/${getGroupingFilename(value)}`,
                     html: detailHtml,
                 };
             });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -90,6 +90,9 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
+      slugify:
+        specifier: ^1.6.9
+        version: 1.6.9
       tabulator-tables:
         specifier: ^6.3.1
         version: 6.3.1

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
+      slugify:
+        specifier: ^1.6.9
+        version: 1.6.9
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1684,6 +1687,10 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
+  slugify@1.6.9:
+    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
+    engines: {node: '>=8.0.0'}
+
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3027,6 +3034,8 @@ snapshots:
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
+
+  slugify@1.6.9: {}
 
   source-map-js@1.2.1: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,9 +35,6 @@ importers:
       semver:
         specifier: ^7.7.4
         version: 7.7.4
-      slugify:
-        specifier: ^1.6.9
-        version: 1.6.9
       zod:
         specifier: ^4.3.6
         version: 4.3.6
@@ -1687,10 +1684,6 @@ packages:
   siginfo@2.0.0:
     resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
 
-  slugify@1.6.9:
-    resolution: {integrity: sha512-vZ7rfeehZui7wQs438JXBckYLkIIdfHOXsaVEUMyS5fHo1483l1bMdo0EDSWYclY0yZKFOipDy4KHuKs6ssvdg==}
-    engines: {node: '>=8.0.0'}
-
   source-map-js@1.2.1:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
@@ -3034,8 +3027,6 @@ snapshots:
   semver@7.7.4: {}
 
   siginfo@2.0.0: {}
-
-  slugify@1.6.9: {}
 
   source-map-js@1.2.1: {}
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,6 +195,7 @@ __metadata:
     handlebars: "npm:^4.7.8"
     js-yaml: "npm:^4.1.1"
     semver: "npm:^7.7.4"
+    slugify: "npm:^1.6.9"
     tsdown: "npm:^0.20.3"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.0"
@@ -3258,6 +3259,13 @@ __metadata:
   version: 2.0.0
   resolution: "siginfo@npm:2.0.0"
   checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
+"slugify@npm:^1.6.9":
+  version: 1.6.9
+  resolution: "slugify@npm:1.6.9"
+  checksum: 10c0/8473c566ae00c5db26bfbf6182a4a9478ab3c912a9c926e1fdb410736a77228bfca4fdc5c755b46fafa7d2d9900de482fd7a9bd5e5c91128c4743c2c072d88da
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -195,7 +195,6 @@ __metadata:
     handlebars: "npm:^4.7.8"
     js-yaml: "npm:^4.1.1"
     semver: "npm:^7.7.4"
-    slugify: "npm:^1.6.9"
     tsdown: "npm:^0.20.3"
     typescript: "npm:^5.9.3"
     vitest: "npm:^4.1.0"
@@ -3259,13 +3258,6 @@ __metadata:
   version: 2.0.0
   resolution: "siginfo@npm:2.0.0"
   checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
-  languageName: node
-  linkType: hard
-
-"slugify@npm:^1.6.9":
-  version: 1.6.9
-  resolution: "slugify@npm:1.6.9"
-  checksum: 10c0/8473c566ae00c5db26bfbf6182a4a9478ab3c912a9c926e1fdb410736a77228bfca4fdc5c755b46fafa7d2d9900de482fd7a9bd5e5c91128c4743c2c072d88da
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1908,6 +1908,7 @@ __metadata:
     open-props: "npm:^1.7.23"
     rolldown: "npm:1.0.0-rc.10"
     semver: "npm:^7.7.4"
+    slugify: "npm:^1.6.9"
     tabulator-tables: "npm:^6.3.1"
     tsdown: "npm:^0.20.3"
     typedoc: "npm:^0.28.17"


### PR DESCRIPTION
Grouping values (surface names, team names) were used raw as both filenames and link hrefs in HtmlWriter.toGroupingPages(). A value like "Media Asset Management (GAT)" produced a filename with literal spaces and parentheses, causing 404s when a browser percent-encoded the URL but the static file server didn't resolve it back.

Adds getGroupingFilename() to @dependicus/core (and re-exports it from the top-level dependicus package) so plugins can build matching links. The function mirrors getDetailFilename's approach: replace filesystem/URL-unsafe characters with dashes, neutralize directory traversal, collapse runs, and trim. Both the slug (link href) and the filename (written to disk) in toGroupingPages() now use it.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: change is isolated to how grouping page filenames/hrefs are generated, plus adds a small `slugify` dependency and associated lockfile updates.
> 
> **Overview**
> Fixes grouping detail page 404s by **slugifying grouping values** (teams/surfaces) before using them as filenames and link hrefs.
> 
> Introduces `getGroupingFilename()` in `@dependicus/core` (and re-exports it from `dependicus`), adds tests for edge cases (spaces, punctuation, traversal, empty), and updates `HtmlWriter.toGroupingPages()` to use the helper consistently. Dependency manifests/lockfiles are updated to include `slugify` and bump the `dependicus` package version to `0.2.0-rc.2`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 12d96c7bed41d02412f5b3db44d5037791d9c6e5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->