### PR TITLE
Scope dependency tickets by ecosystem to prevent cross-registry merges

### DIFF
--- a/src/core/utils/versionUtils.test.ts
+++ b/src/core/utils/versionUtils.test.ts
@@ -211,6 +211,30 @@ describe('extractDependencyNameFromTitle', () => {
         ).toBe('react-utils');
     });
 
+    it('extracts ecosystem::name from title with ecosystem tag', () => {
+        expect(
+            extractDependencyNameFromTitle(
+                '[Dependicus] [npm] Update braintrust from 0.1.0 to 3.9.0',
+            ),
+        ).toBe('npm::braintrust');
+    });
+
+    it('extracts ecosystem::name from FYI title with ecosystem tag', () => {
+        expect(
+            extractDependencyNameFromTitle(
+                '[Dependicus] [pypi] FYI: braintrust 0.18.0 is available (currently on 0.2.1)',
+            ),
+        ).toBe('pypi::braintrust');
+    });
+
+    it('extracts ecosystem::name for scoped packages with ecosystem tag', () => {
+        expect(
+            extractDependencyNameFromTitle(
+                '[Dependicus] [npm] Update @linear/sdk from 32.0.0 to 65.0.0',
+            ),
+        ).toBe('npm::@linear/sdk');
+    });
+
     it('returns undefined for non-Dependicus titles', () => {
         expect(extractDependencyNameFromTitle('Update react to 19.0.0')).toBeUndefined();
         expect(extractDependencyNameFromTitle('Fix bug in react')).toBeUndefined();
@@ -251,6 +275,27 @@ describe('buildTicketTitle', () => {
                 notificationsOnly: true,
             }),
         ).toBe('FYI: stytch 13.2.0 is available (currently on 12.19.0)');
+    });
+
+    it('includes ecosystem tag when ecosystem is provided', () => {
+        expect(
+            buildTicketTitle('braintrust', '0.1.0', '3.9.0', '3.9.0', { ecosystem: 'npm' }),
+        ).toBe('[npm] Update braintrust from 0.1.0 to 3.9.0');
+    });
+
+    it('includes ecosystem tag in FYI titles', () => {
+        expect(
+            buildTicketTitle('braintrust', '0.2.1', '0.18.0', '0.18.0', {
+                notificationsOnly: true,
+                ecosystem: 'pypi',
+            }),
+        ).toBe('[pypi] FYI: braintrust 0.18.0 is available (currently on 0.2.1)');
+    });
+
+    it('includes ecosystem tag in "at least" titles', () => {
+        expect(buildTicketTitle('react', '18.2.0', '19.0.0', '19.2.3', { ecosystem: 'npm' })).toBe(
+            '[npm] Update react from 18.2.0 to at least 19.0.0 (latest: 19.2.3)',
+        );
     });
 });
 

--- a/src/core/utils/versionUtils.ts
+++ b/src/core/utils/versionUtils.ts
@@ -127,13 +127,25 @@ export function extractLatestVersionFromTitle(title: string): string | undefined
  * - "[Dependicus] FYI: <dependency> X.Y.Z is available"
  */
 export function extractDependencyNameFromTitle(title: string): string | undefined {
-    // Try standard "Update X from..." format
+    // Try new format with ecosystem tag: "[Dependicus] [npm] Update X from..."
+    const ecoUpdateMatch = title.match(/^\[Dependicus\]\s+\[(\w+)\]\s+Update\s+(.+?)\s+from\s+/);
+    if (ecoUpdateMatch) {
+        return `${ecoUpdateMatch[1]}::${ecoUpdateMatch[2]}`;
+    }
+
+    // Try new FYI format with ecosystem tag: "[Dependicus] [npm] FYI: X Y.Z is available"
+    const ecoFyiMatch = title.match(/^\[Dependicus\]\s+\[(\w+)\]\s+FYI:\s+(.+?)\s+\d+\.\d+/);
+    if (ecoFyiMatch) {
+        return `${ecoFyiMatch[1]}::${ecoFyiMatch[2]}`;
+    }
+
+    // Backward compat: standard "Update X from..." format (no ecosystem tag)
     const updateMatch = title.match(/^\[Dependicus\]\s+Update\s+(.+?)\s+from\s+/);
     if (updateMatch) {
         return updateMatch[1];
     }
 
-    // Try FYI format: "FYI: <package> X.Y.Z is available"
+    // Backward compat: FYI format (no ecosystem tag)
     const fyiMatch = title.match(/^\[Dependicus\]\s+FYI:\s+(.+?)\s+\d+\.\d+/);
     if (fyiMatch) {
         return fyiMatch[1];
@@ -193,20 +205,22 @@ export function buildTicketTitle(
     currentVersion: string,
     minVersion: string,
     latestVersion: string,
-    options?: { notificationsOnly?: boolean },
+    options?: { notificationsOnly?: boolean; ecosystem?: string },
 ): string {
+    const prefix = options?.ecosystem ? `[${options.ecosystem}] ` : '';
+
     // Notifications-only dependencies get FYI-style titles since no update is mandatory
     if (options?.notificationsOnly) {
         if (currentVersion === minVersion || minVersion === latestVersion) {
-            return `FYI: ${name} ${latestVersion} is available (currently on ${currentVersion})`;
+            return `${prefix}FYI: ${name} ${latestVersion} is available (currently on ${currentVersion})`;
         }
-        return `FYI: ${name} ${latestVersion} is available (currently on ${currentVersion})`;
+        return `${prefix}FYI: ${name} ${latestVersion} is available (currently on ${currentVersion})`;
     }
 
     if (minVersion === latestVersion) {
-        return `Update ${name} from ${currentVersion} to ${latestVersion}`;
+        return `${prefix}Update ${name} from ${currentVersion} to ${latestVersion}`;
     }
-    return `Update ${name} from ${currentVersion} to at least ${minVersion} (latest: ${latestVersion})`;
+    return `${prefix}Update ${name} from ${currentVersion} to at least ${minVersion} (latest: ${latestVersion})`;
 }
 
 /**

--- a/src/github-issues/issueReconciler.test.ts
+++ b/src/github-issues/issueReconciler.test.ts
@@ -369,6 +369,84 @@ describe('reconcileGitHubIssues', () => {
         expect(mockOctokit.issues.create).not.toHaveBeenCalled();
     });
 
+    it('creates separate issues for same-name packages in different ecosystems', async () => {
+        setupMocks();
+
+        const npmVersion = makeVersion();
+        const pypiVersion = makeVersion({
+            version: '0.2.1',
+            latestVersion: '0.18.0',
+        });
+
+        const root = new RootFactStore();
+        // npm facts
+        const npmScoped = root.scoped('npm');
+        npmScoped.setVersionFact('braintrust', '1.0.0', FactKeys.VERSIONS_BETWEEN, [
+            { version: '2.0.0', publishDate: '2024-06-01', isPrerelease: false },
+        ]);
+        npmScoped.setVersionFact('braintrust', '1.0.0', FactKeys.DESCRIPTION, 'npm package');
+        // pypi facts
+        const pypiScoped = root.scoped('pypi');
+        pypiScoped.setVersionFact('braintrust', '0.2.1', FactKeys.VERSIONS_BETWEEN, [
+            { version: '0.18.0', publishDate: '2024-06-01', isPrerelease: false },
+        ]);
+        pypiScoped.setVersionFact('braintrust', '0.2.1', FactKeys.DESCRIPTION, 'pypi package');
+
+        const config: IssueReconcilerConfig = {
+            ...baseConfig,
+            providerInfoMap: new Map([
+                ...baseConfig.providerInfoMap,
+                [
+                    'pypi',
+                    {
+                        name: 'uv',
+                        ecosystem: 'pypi',
+                        supportsCatalog: false,
+                        installCommand: 'uv pip install',
+                        urlPatterns: { Registry: 'https://pypi.org/project/{{name}}' },
+                    },
+                ],
+            ]),
+        };
+
+        const deps: DirectDependency[] = [
+            { name: 'braintrust', ecosystem: 'npm', versions: [npmVersion] },
+            { name: 'braintrust', ecosystem: 'pypi', versions: [pypiVersion] },
+        ];
+
+        const result = await reconcileGitHubIssues(deps, root, config, () =>
+            makeSpec({ policy: { type: 'fyi' } }),
+        );
+
+        // Should create 2 separate issues, not 1 merged issue
+        expect(result.created).toBe(2);
+    });
+
+    it('migrates old issue in place when ecosystem tag is missing from title', async () => {
+        setupMocks([
+            {
+                number: 50,
+                title: '[Dependicus] Update test-pkg from 1.0.0 to 2.0.0',
+                updated_at: '2024-01-01T00:00:00Z',
+                body: 'old description',
+            },
+        ]);
+
+        const deps: DirectDependency[] = [
+            { name: 'test-pkg', ecosystem: 'npm', versions: [makeVersion()] },
+        ];
+        const store = makeStore();
+
+        const result = await reconcileGitHubIssues(deps, store, baseConfig, () =>
+            makeSpec({ policy: { type: 'fyi' } }),
+        );
+
+        // Should update the existing issue in place (fallback match on unqualified name)
+        expect(result.updated).toBe(1);
+        expect(result.created).toBe(0);
+        expect(result.closed).toBe(0);
+    });
+
     it('returns zeros when no outdated packages', async () => {
         setupMocks();
 

--- a/src/github-issues/issueReconciler.ts
+++ b/src/github-issues/issueReconciler.ts
@@ -180,6 +180,23 @@ function shouldSkipCreateDueToRateLimit(
     return undefined;
 }
 
+/**
+ * Look up an existing issue by ecosystem-qualified key, falling back to
+ * the unqualified name for backward compatibility with issues created
+ * before the ecosystem tag was added to titles.
+ */
+function findExistingIssue(
+    map: Map<string, DependicusIssue>,
+    qualifiedKey: string,
+    unqualifiedName: string,
+): { issue: DependicusIssue; mapKey: string } | undefined {
+    const byQualified = map.get(qualifiedKey);
+    if (byQualified) return { issue: byQualified, mapKey: qualifiedKey };
+    const byName = map.get(unqualifiedName);
+    if (byName) return { issue: byName, mapKey: unqualifiedName };
+    return undefined;
+}
+
 /** Default policy when the issue spec doesn't specify one. */
 const DEFAULT_POLICY: GitHubIssuePolicy = { type: 'fyi' };
 
@@ -233,10 +250,12 @@ export async function reconcileGitHubIssues(
 
     const githubService = new GitHubIssueService(config.githubToken, { dryRun });
 
-    // Find out-of-date dependencies (group by dependency name)
+    // Find out-of-date dependencies (group by ecosystem::name to avoid
+    // merging packages that share a name across different registries)
     const outdatedDeps = new Map<string, OutdatedDependency>();
 
     for (const dep of dependencies) {
+        const depKey = `${dep.ecosystem}::${dep.name}`;
         for (const version of dep.versions) {
             if (version.version === version.latestVersion) continue;
 
@@ -285,10 +304,10 @@ export async function reconcileGitHubIssues(
                   ? policy
                   : { type: 'fyi' as const, rateLimitDays: policyRateLimitDays(policy) };
 
-            const existing = outdatedDeps.get(dep.name);
+            const existing = outdatedDeps.get(depKey);
 
             if (!existing) {
-                outdatedDeps.set(dep.name, {
+                outdatedDeps.set(depKey, {
                     name: dep.name,
                     ecosystem: dep.ecosystem,
                     versions: [version],
@@ -344,13 +363,13 @@ export async function reconcileGitHubIssues(
     const ungroupedDeps = new Map<string, OutdatedDependency>();
     const dependenciesByGroup = new Map<string, OutdatedDependency[]>();
 
-    for (const dep of outdatedDeps.values()) {
+    for (const [key, dep] of outdatedDeps) {
         if (dep.group) {
             const groupDeps = dependenciesByGroup.get(dep.group) ?? [];
             groupDeps.push(dep);
             dependenciesByGroup.set(dep.group, groupDeps);
         } else {
-            ungroupedDeps.set(dep.name, dep);
+            ungroupedDeps.set(key, dep);
         }
     }
 
@@ -462,7 +481,9 @@ export async function reconcileGitHubIssues(
 
     // Process ungrouped dependencies
     for (const dep of ungroupedDeps.values()) {
-        const existingIssue = existingIssuesByDependency.get(dep.name);
+        const depKey = `${dep.ecosystem}::${dep.name}`;
+        const match = findExistingIssue(existingIssuesByDependency, depKey, dep.name);
+        const existingIssue = match?.issue;
         const version = dep.versions[0];
         if (!version) {
             throw new Error(`No versions found for dependency ${dep.name}`);
@@ -507,7 +528,7 @@ export async function reconcileGitHubIssues(
             version.version,
             minVersion,
             effectiveLatestVersion,
-            { notificationsOnly },
+            { notificationsOnly, ecosystem: dep.ecosystem },
         );
         if (dueDateStr && !notificationsOnly) {
             title = `${title} (due ${dueDateStr})`;
@@ -544,7 +565,7 @@ export async function reconcileGitHubIssues(
                         `Skipping ${dep.name} (#${existingIssue.number}) - within ${skipRateLimitDays}-day rate limit\n`,
                     );
                 }
-                existingIssuesByDependency.delete(dep.name);
+                existingIssuesByDependency.delete(match!.mapKey);
                 continue;
             }
 
@@ -599,7 +620,7 @@ export async function reconcileGitHubIssues(
                 }
             }
 
-            existingIssuesByDependency.delete(dep.name);
+            existingIssuesByDependency.delete(match!.mapKey);
         } else {
             // No issue exists - only create if allowed
             if (!allowNewIssues) {

--- a/src/linear/issueReconciler.test.ts
+++ b/src/linear/issueReconciler.test.ts
@@ -1120,6 +1120,81 @@ describe('reconcileIssues', () => {
         });
     });
 
+    it('creates separate issues for same-name packages in different ecosystems', async () => {
+        const npmVersion = makeVersion();
+        const pypiVersion = makeVersion({
+            version: '0.2.1',
+            latestVersion: '0.18.0',
+        });
+
+        populateFacts(store, 'braintrust', npmVersion);
+        // Populate facts for the pypi ecosystem
+        const pypiScoped = store.scoped('pypi');
+        pypiScoped.setVersionFact('braintrust', '0.2.1', FactKeys.VERSIONS_BETWEEN, [
+            {
+                version: '0.18.0',
+                publishDate: '2024-06-01',
+                isPrerelease: false,
+            },
+        ]);
+        pypiScoped.setVersionFact('braintrust', '0.2.1', FactKeys.DESCRIPTION, 'A test package');
+        pypiScoped.setDependencyFact('braintrust', 'testMeta', defaultMeta);
+
+        const config: IssueReconcilerConfig = {
+            ...defaultConfig,
+            providerInfoMap: new Map([
+                ...defaultConfig.providerInfoMap,
+                [
+                    'pypi',
+                    {
+                        name: 'uv',
+                        ecosystem: 'pypi',
+                        supportsCatalog: false,
+                        installCommand: 'uv pip install',
+                        urlPatterns: { Registry: 'https://pypi.org/project/{{name}}' },
+                    },
+                ],
+            ]),
+        };
+
+        const deps: DirectDependency[] = [
+            { name: 'braintrust', ecosystem: 'npm', versions: [npmVersion] },
+            { name: 'braintrust', ecosystem: 'pypi', versions: [pypiVersion] },
+        ];
+
+        const result = await reconcileIssues(deps, store, config, testGetLinearIssueSpec);
+        // Should create 2 separate issues, not 1 merged issue
+        expect(result.created).toBe(2);
+    });
+
+    it('migrates old issue in place when ecosystem tag is missing from title', async () => {
+        const mockState = { type: 'unstarted', name: 'Todo' };
+        // Old issue without ecosystem tag in title
+        mockClient.issues.mockResolvedValue({
+            nodes: [
+                {
+                    id: 'issue-1',
+                    identifier: 'TEST-50',
+                    title: '[Dependicus] Update test-pkg from 1.0.0 to 2.0.0',
+                    dueDate: '2025-06-01',
+                    updatedAt: new Date('2024-01-01'),
+                    state: Promise.resolve(mockState),
+                },
+            ],
+            pageInfo: { hasNextPage: false, endCursor: undefined },
+        });
+
+        const v = makeVersion();
+        populateFacts(store, 'test-pkg', v);
+        const deps: DirectDependency[] = [makeDep('test-pkg', [v])];
+
+        const result = await reconcileIssues(deps, store, defaultConfig, testGetLinearIssueSpec);
+        // Should update the existing issue in place (fallback match on unqualified name)
+        expect(result.updated).toBe(1);
+        expect(result.created).toBe(0);
+        expect(result.closed).toBe(0);
+    });
+
     it('handles empty dependencies list', async () => {
         const deps: DirectDependency[] = [];
         const result = await reconcileIssues(deps, store, defaultConfig, testGetLinearIssueSpec);

--- a/src/linear/issueReconciler.ts
+++ b/src/linear/issueReconciler.ts
@@ -190,6 +190,23 @@ function shouldSkipCreateDueToRateLimit(
     return undefined;
 }
 
+/**
+ * Look up an existing issue by ecosystem-qualified key, falling back to
+ * the unqualified name for backward compatibility with issues created
+ * before the ecosystem tag was added to titles.
+ */
+function findExistingIssue(
+    map: Map<string, DependicusIssue>,
+    qualifiedKey: string,
+    unqualifiedName: string,
+): { issue: DependicusIssue; mapKey: string } | undefined {
+    const byQualified = map.get(qualifiedKey);
+    if (byQualified) return { issue: byQualified, mapKey: qualifiedKey };
+    const byName = map.get(unqualifiedName);
+    if (byName) return { issue: byName, mapKey: unqualifiedName };
+    return undefined;
+}
+
 /** Default policy when the issue spec doesn't specify one. */
 const DEFAULT_POLICY: LinearPolicy = { type: 'fyi' };
 
@@ -240,10 +257,12 @@ export async function reconcileIssues(
 
     const linearService = new LinearService(config.linearApiKey, { dryRun });
 
-    // Find out-of-date dependencies (group by dependency name)
+    // Find out-of-date dependencies (group by ecosystem::name to avoid
+    // merging packages that share a name across different registries)
     const outdatedDeps = new Map<string, OutdatedDependency>();
 
     for (const dep of dependencies) {
+        const depKey = `${dep.ecosystem}::${dep.name}`;
         for (const version of dep.versions) {
             // Skip if already on latest version
             if (version.version === version.latestVersion) continue;
@@ -299,10 +318,10 @@ export async function reconcileIssues(
                   ? policy
                   : { type: 'fyi' as const, rateLimitDays: policyRateLimitDays(policy) };
 
-            const existing = outdatedDeps.get(dep.name);
+            const existing = outdatedDeps.get(depKey);
 
             if (!existing) {
-                outdatedDeps.set(dep.name, {
+                outdatedDeps.set(depKey, {
                     name: dep.name,
                     ecosystem: dep.ecosystem,
                     versions: [version],
@@ -359,13 +378,13 @@ export async function reconcileIssues(
     const ungroupedDeps = new Map<string, OutdatedDependency>();
     const dependenciesByGroup = new Map<string, OutdatedDependency[]>();
 
-    for (const dep of outdatedDeps.values()) {
+    for (const [key, dep] of outdatedDeps) {
         if (dep.group) {
             const groupDeps = dependenciesByGroup.get(dep.group) ?? [];
             groupDeps.push(dep);
             dependenciesByGroup.set(dep.group, groupDeps);
         } else {
-            ungroupedDeps.set(dep.name, dep);
+            ungroupedDeps.set(key, dep);
         }
     }
 
@@ -462,7 +481,9 @@ export async function reconcileIssues(
 
     // Process ungrouped dependencies
     for (const dep of ungroupedDeps.values()) {
-        const existingIssue = existingIssuesByName.get(dep.name);
+        const depKey = `${dep.ecosystem}::${dep.name}`;
+        const match = findExistingIssue(existingIssuesByName, depKey, dep.name);
+        const existingIssue = match?.issue;
         const version = dep.versions[0];
         if (!version) {
             throw new Error(`No versions found for dependency ${dep.name}`);
@@ -505,7 +526,7 @@ export async function reconcileIssues(
             version.version,
             minVersion,
             effectiveLatestVersion,
-            { notificationsOnly },
+            { notificationsOnly, ecosystem: dep.ecosystem },
         );
         const providerInfo = config.providerInfoMap.get(dep.ecosystem);
         if (!providerInfo) {
@@ -532,7 +553,7 @@ export async function reconcileIssues(
                         `Skipping ${dep.name} (${existingIssue.identifier}) - issue in ${existingIssue.state.name} state\n`,
                     );
                 }
-                existingIssuesByName.delete(dep.name);
+                existingIssuesByName.delete(match!.mapKey);
                 continue;
             }
 
@@ -553,7 +574,7 @@ export async function reconcileIssues(
                         `Skipping ${dep.name} (${existingIssue.identifier}) - within ${skipRateLimitDays}-day rate limit\n`,
                     );
                 }
-                existingIssuesByName.delete(dep.name);
+                existingIssuesByName.delete(match!.mapKey);
                 continue;
             }
 
@@ -605,7 +626,7 @@ export async function reconcileIssues(
             }
             updated++;
 
-            existingIssuesByName.delete(dep.name);
+            existingIssuesByName.delete(match!.mapKey);
         } else {
             // No issue exists - only create if allowed
             if (!allowNewIssues) {


### PR DESCRIPTION
When an npm package and a PyPI package share the same name (e.g., "braintrust"), they were merged into a single ticket with a nonsensical mixed target version. The root cause was that both issue reconcilers keyed their internal dedup maps by package name alone, even though mergeProviderDependencies() already correctly keys by ecosystem::name.

The fix has three parts:

Ticket titles now include an ecosystem tag: "[Dependicus] [npm] Update braintrust from 0.1.0 to 3.9.0". extractDependencyNameFromTitle parses the tag and returns "npm::braintrust" as the dependency identity.

Internal maps in both the Linear and GitHub reconcilers now key by ecosystem::name, so same-name packages from different registries produce separate tickets.

A findExistingIssue helper provides backward compatibility: it tries the qualified key first, then falls back to the bare name. Old issues (without ecosystem tags) get updated in place rather than closed and recreated. The first ecosystem to claim an old issue wins; other ecosystems get new properly-scoped issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes issue deduplication and matching logic in both GitHub and Linear reconcilers, which could affect whether issues are updated vs created/closed if keying or title parsing is wrong. Backward-compat fallback matching and added tests reduce risk but behavior changes in production issue management.
> 
> **Overview**
> Prevents same-name packages from different registries (e.g., npm vs PyPI) from being merged into a single Dependicus ticket by **scoping dependency identity to `ecosystem::name` end-to-end**.
> 
> Ticket titles now include an ecosystem tag (e.g., `[npm] ...`), `extractDependencyNameFromTitle` can parse the new tagged format, and `buildTicketTitle` optionally prefixes titles with the ecosystem.
> 
> Both the GitHub and Linear issue reconcilers now key their internal “outdated dependency” and “existing issue” maps by `ecosystem::name`, while a new `findExistingIssue` fallback lets previously-created untagged issues be updated in place instead of being recreated. Tests were added to assert cross-ecosystem separation and migration behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d46128ae1d6e5c03c74b7de20005880dcaae779d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->