### PR TITLE
Fix CSS not being inlined in dashboard HTML

### DIFF
--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -5,9 +5,18 @@ import type { Plugin } from 'rolldown';
 function inlineRawFiles(): Plugin {
     return {
         name: 'inline-raw-files',
+        resolveId(source, importer) {
+            // Redirect .css imports to a virtual .cssraw ID so rolldown's
+            // native CSS handling doesn't extract them into separate files.
+            if (source.endsWith('.css') && importer) {
+                const resolved = new URL(source, 'file://' + importer).pathname;
+                return { id: resolved + '.cssraw' };
+            }
+        },
         load(id) {
-            if (id.endsWith('.hbs') || id.endsWith('.css') || id.endsWith('.asset.js')) {
-                const content = readFileSync(id, 'utf-8');
+            const rawPath = id.endsWith('.cssraw') ? id.slice(0, -'.cssraw'.length) : null;
+            if (rawPath || id.endsWith('.hbs') || id.endsWith('.asset.js')) {
+                const content = readFileSync(rawPath ?? id, 'utf-8');
                 return `export default ${JSON.stringify(content)};`;
             }
         },

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
 import { defineConfig } from 'tsdown';
 import type { Plugin } from 'rolldown';
 
@@ -9,7 +10,7 @@ function inlineRawFiles(): Plugin {
             // Redirect .css imports to a virtual .cssraw ID so rolldown's
             // native CSS handling doesn't extract them into separate files.
             if (source.endsWith('.css') && importer) {
-                const resolved = new URL(source, 'file://' + importer).pathname;
+                const resolved = resolve(dirname(importer), source);
                 return { id: resolved + '.cssraw' };
             }
         },


### PR DESCRIPTION
tsdown/rolldown's native CSS handling was intercepting .css imports before our inlineRawFiles plugin could run, extracting them into separate files and exporting empty objects. The dashboard's styles.css was silently dropped from the HTML output, leaving all tabs, provider pills, and badge styling unstyled.

Fixed by adding a resolveId hook that redirects .css imports to a virtual .cssraw extension, bypassing rolldown's CSS extraction while still reading and inlining the file content via the load hook.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk build-config change limited to how `.css` files are resolved/loaded for bundling; main risk is unexpected handling of CSS import resolution paths.
> 
> **Overview**
> Fixes CSS imports being dropped/extracted during bundling by updating `inlineRawFiles` in `tsdown.config.ts`.
> 
> The plugin now intercepts `.css` imports in `resolveId` and rewrites them to a virtual `.cssraw` path, then `load` reads the original file and exports its contents as a string so CSS is inlined instead of handled by rolldown’s native CSS pipeline.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2f17886d1fca40eb368e2e3446161ad272420fdc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->