### PR TITLE
Strip ecosystem prefix from lifecycle comment text

### DIFF
--- a/src/github-issues/issueDescriptions.test.ts
+++ b/src/github-issues/issueDescriptions.test.ts
@@ -525,6 +525,7 @@ describe('buildIssueClosedComment', () => {
     it('includes version info for individual dependency', () => {
         const result = buildIssueClosedComment({
             name: 'test-pkg',
+            ecosystem: 'npm',
             isGroup: false,
             currentVersion: '2.0.0',
             latestVersion: '2.0.0',
@@ -532,6 +533,18 @@ describe('buildIssueClosedComment', () => {
         expect(result).toContain('Closed by Dependicus');
         expect(result).toContain('test-pkg');
         expect(result).toContain('now at version');
+    });
+
+    it('renders bare name without ecosystem prefix', () => {
+        const result = buildIssueClosedComment({
+            name: 'electron',
+            ecosystem: 'npm',
+            isGroup: false,
+            currentVersion: '30.0.0',
+            latestVersion: '30.0.0',
+        });
+        expect(result).toContain('**electron**');
+        expect(result).not.toContain('npm::');
     });
 
     it('handles group issues without version info', () => {
@@ -556,6 +569,7 @@ describe('buildIssueReopenedComment', () => {
     it('includes version info for individual dependency', () => {
         const result = buildIssueReopenedComment({
             name: 'test-pkg',
+            ecosystem: 'npm',
             isGroup: false,
             isFyi: false,
             updateType: 'major',
@@ -566,6 +580,7 @@ describe('buildIssueReopenedComment', () => {
         });
         expect(result).toContain('Reopened by Dependicus');
         expect(result).toContain('test-pkg');
+        expect(result).not.toContain('npm::');
         expect(result).toContain('1.0.0');
         expect(result).toContain('2.0.0');
     });
@@ -588,6 +603,7 @@ describe('buildIssueReopenedComment', () => {
     it('renders comment sections when provided', () => {
         const result = buildIssueReopenedComment({
             name: 'test-pkg',
+            ecosystem: 'npm',
             isGroup: false,
             isFyi: false,
             updateType: 'minor',

--- a/src/github-issues/issueDescriptions.ts
+++ b/src/github-issues/issueDescriptions.ts
@@ -313,6 +313,7 @@ export function buildNewVersionsComment(
 
 export interface IssueReopenedCommentParams {
     name: string;
+    ecosystem?: string;
     isGroup: boolean;
     isFyi: boolean;
     updateType: string;
@@ -325,6 +326,7 @@ export interface IssueReopenedCommentParams {
 
 export interface IssueClosedCommentParams {
     name: string;
+    ecosystem?: string;
     isGroup: boolean;
     /** Current installed version. Present when the dep is in the input (compliant). */
     currentVersion?: string;

--- a/src/github-issues/issueReconciler.ts
+++ b/src/github-issues/issueReconciler.ts
@@ -706,6 +706,7 @@ export async function reconcileGitHubIssues(
 
                 const reopenedComment = buildIssueReopenedComment({
                     name: dep.name,
+                    ecosystem: dep.ecosystem,
                     isGroup: false,
                     isFyi: notificationsOnly,
                     updateType: dep.worstCompliance.updateType,
@@ -967,8 +968,12 @@ export async function reconcileGitHubIssues(
         const reportedDep = reportedDeps.get(issue.dependencyName);
         const firstVersion = reportedDep?.versions[0];
 
+        const [depEcosystem, depName] = issue.dependencyName.includes('::')
+            ? issue.dependencyName.split('::')
+            : [undefined, issue.dependencyName];
         const closeComment = buildIssueClosedComment({
-            name: issue.dependencyName,
+            name: depName!,
+            ecosystem: depEcosystem,
             isGroup: issue.isGroup,
             currentVersion: firstVersion?.version,
             latestVersion: firstVersion?.latestVersion,

--- a/src/linear/issueDescriptions.test.ts
+++ b/src/linear/issueDescriptions.test.ts
@@ -836,6 +836,7 @@ describe('buildIssueClosedComment', () => {
     it('includes version info for individual dependency', () => {
         const result = buildIssueClosedComment({
             name: 'test-pkg',
+            ecosystem: 'npm',
             isGroup: false,
             currentVersion: '2.0.0',
             latestVersion: '2.0.0',
@@ -843,6 +844,18 @@ describe('buildIssueClosedComment', () => {
         expect(result).toContain('Closed by Dependicus');
         expect(result).toContain('test-pkg');
         expect(result).toContain('now at version');
+    });
+
+    it('renders bare name without ecosystem prefix', () => {
+        const result = buildIssueClosedComment({
+            name: 'electron',
+            ecosystem: 'npm',
+            isGroup: false,
+            currentVersion: '30.0.0',
+            latestVersion: '30.0.0',
+        });
+        expect(result).toContain('**electron**');
+        expect(result).not.toContain('npm::');
     });
 
     it('handles group issues without version info', () => {
@@ -867,6 +880,7 @@ describe('buildIssueReopenedComment', () => {
     it('includes version info for individual dependency', () => {
         const result = buildIssueReopenedComment({
             name: 'test-pkg',
+            ecosystem: 'npm',
             isGroup: false,
             isFyi: false,
             updateType: 'major',
@@ -877,6 +891,7 @@ describe('buildIssueReopenedComment', () => {
         });
         expect(result).toContain('Reopened by Dependicus');
         expect(result).toContain('test-pkg');
+        expect(result).not.toContain('npm::');
         expect(result).toContain('1.0.0');
         expect(result).toContain('2.0.0');
     });
@@ -899,6 +914,7 @@ describe('buildIssueReopenedComment', () => {
     it('renders comment sections when provided', () => {
         const result = buildIssueReopenedComment({
             name: 'test-pkg',
+            ecosystem: 'npm',
             isGroup: false,
             isFyi: false,
             updateType: 'minor',

--- a/src/linear/issueDescriptions.ts
+++ b/src/linear/issueDescriptions.ts
@@ -307,6 +307,7 @@ export function buildNewVersionsComment(
 
 export interface IssueReopenedCommentParams {
     name: string;
+    ecosystem?: string;
     isGroup: boolean;
     isFyi: boolean;
     updateType: string;
@@ -319,6 +320,7 @@ export interface IssueReopenedCommentParams {
 
 export interface IssueClosedCommentParams {
     name: string;
+    ecosystem?: string;
     isGroup: boolean;
     /** Current installed version. Present when the dep is in the input (compliant). */
     currentVersion?: string;

--- a/src/linear/issueReconciler.ts
+++ b/src/linear/issueReconciler.ts
@@ -710,6 +710,7 @@ export async function reconcileIssues(
 
                 const reopenedComment = buildIssueReopenedComment({
                     name: dep.name,
+                    ecosystem: dep.ecosystem,
                     isGroup: false,
                     isFyi: notificationsOnly,
                     updateType: dep.worstCompliance.updateType,
@@ -978,8 +979,12 @@ export async function reconcileIssues(
         const reportedDep = reportedDeps.get(issue.dependencyName);
         const firstVersion = reportedDep?.versions[0];
 
+        const [depEcosystem, depName] = issue.dependencyName.includes('::')
+            ? issue.dependencyName.split('::')
+            : [undefined, issue.dependencyName];
         const closeComment = buildIssueClosedComment({
-            name: issue.dependencyName,
+            name: depName!,
+            ecosystem: depEcosystem,
             isGroup: issue.isGroup,
             currentVersion: firstVersion?.version,
             latestVersion: firstVersion?.latestVersion,


### PR DESCRIPTION
`issue.dependencyName` is ecosystem-qualified for new-format titles (e.g. `npm::electron`), but this internal identifier was leaking into close and reopen comments verbatim. Now the call sites split the qualified key into a bare `name` and `ecosystem` before passing them to the comment builders. The templates render only the bare name; `ecosystem` is carried on the params for future use but not displayed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: only adjusts lifecycle comment inputs (name parsing + optional `ecosystem` param) for GitHub/Linear, with tests covering that `ecosystem::` no longer leaks into comment text.
> 
> **Overview**
> Stops ecosystem-qualified dependency keys (e.g. `npm::electron`) from leaking into GitHub/Linear *close* and *reopen* lifecycle comments.
> 
> Call sites now split `issue.dependencyName` into `{ ecosystem, name }` before building close comments, and reopen comment params include an optional `ecosystem` field; tests were updated/added to assert comments render the bare package name and never include the `::` prefix.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit dfb14ab507057479f11d7465ad59101313b52a0d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->