### PR TITLE
Switch to npm trusted publishing via OIDC

### DIFF
--- a/.claude/commands/prerelease.md
+++ b/.claude/commands/prerelease.md
@@ -2,15 +2,15 @@
 2. Parse the current version from `packages/dependicus/package.json`
 3. Validate the version is in format `X.Y.Z-rc.N` (e.g., `0.1.9-rc.5`)
     - If not in this format, ERROR and tell the user to manually fix it first
-4. **STOP and ask the user to run `mise prerelease`**. Wait for them to confirm that the publish succeeded before continuing.
-5. After the user confirms, tag, push, and create a GitHub prerelease:
+4. Tag, push, and create a GitHub prerelease:
     ```bash
     git tag v<current-version>
     git push origin main
     git push origin v<current-version>
     gh release create v<current-version> --prerelease --title "v<current-version>" --notes ""
     ```
-6. Increment the rc number: `-rc.5` → `-rc.6`
+5. **STOP and wait for the user to confirm that the publish workflow succeeded** (the GitHub release triggers the publish workflow automatically).
+6. After the user confirms, increment the rc number: `-rc.5` → `-rc.6`
 7. Update the version in `packages/dependicus/package.json`
 8. Run `mise update-all-lockfiles` to update all lockfiles
 9. Commit and push:

--- a/.claude/commands/prerelease.md
+++ b/.claude/commands/prerelease.md
@@ -9,11 +9,10 @@
     git push origin v<current-version>
     gh release create v<current-version> --prerelease --title "v<current-version>" --notes ""
     ```
-5. **STOP and wait for the user to confirm that the publish workflow succeeded** (the GitHub release triggers the publish workflow automatically).
-6. After the user confirms, increment the rc number: `-rc.5` → `-rc.6`
-7. Update the version in `packages/dependicus/package.json`
-8. Run `mise update-all-lockfiles` to update all lockfiles
-9. Commit and push:
+5. Increment the rc number: `-rc.5` → `-rc.6`
+6. Update the version in `packages/dependicus/package.json`
+7. Run `mise update-all-lockfiles` to update all lockfiles
+8. Commit and push:
     ```bash
     git add packages/dependicus/package.json pnpm-lock.yaml package-lock.json yarn.lock bun.lock
     git commit -m "Begin v<new-version> development"

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -17,8 +17,7 @@
     git push origin v<version>
     gh release create v<version> --title "v<version>" --notes-file <(extract release notes from CHANGELOG.md for this version)
     ```
-9. **STOP and wait for the user to confirm that the publish workflow succeeded** (the GitHub release triggers the publish workflow automatically).
-10. After the user confirms, bump to the next patch version with `-rc.0` suffix (e.g., `0.1.9` → `0.1.10-rc.0`), add a new unreleased section to CHANGELOG.md, run `mise update-all-lockfiles`, then commit and push:
+9. Bump to the next patch version with `-rc.0` suffix (e.g., `0.1.9` → `0.1.10-rc.0`), add a new unreleased section to CHANGELOG.md, run `mise update-all-lockfiles`, then commit and push:
     ```bash
     git add packages/dependicus/package.json CHANGELOG.md pnpm-lock.yaml package-lock.json yarn.lock bun.lock
     git commit -m "Begin v<next-version> development"

--- a/.claude/commands/release.md
+++ b/.claude/commands/release.md
@@ -10,19 +10,15 @@
     git add packages/dependicus/package.json CHANGELOG.md pnpm-lock.yaml package-lock.json yarn.lock bun.lock
     git commit -m "Release v<version>"
     ```
-8. **STOP and ask the user to run `mise release`**. Wait for them to confirm that the publish succeeded before continuing.
-9. After the user confirms:
-    - Create and push the tag:
-        ```bash
-        git tag v<version>
-        git push origin main
-        git push origin v<version>
-        ```
-    - Create a GitHub release with the changelog notes for this version:
-        ```bash
-        gh release create v<version> --title "v<version>" --notes-file <(extract release notes from CHANGELOG.md for this version)
-        ```
-10. Bump to the next patch version with `-rc.0` suffix (e.g., `0.1.9` → `0.1.10-rc.0`), add a new unreleased section to CHANGELOG.md, run `mise update-all-lockfiles`, then commit and push:
+8. Tag, push, and create a GitHub release with the changelog notes:
+    ```bash
+    git tag v<version>
+    git push origin main
+    git push origin v<version>
+    gh release create v<version> --title "v<version>" --notes-file <(extract release notes from CHANGELOG.md for this version)
+    ```
+9. **STOP and wait for the user to confirm that the publish workflow succeeded** (the GitHub release triggers the publish workflow automatically).
+10. After the user confirms, bump to the next patch version with `-rc.0` suffix (e.g., `0.1.9` → `0.1.10-rc.0`), add a new unreleased section to CHANGELOG.md, run `mise update-all-lockfiles`, then commit and push:
     ```bash
     git add packages/dependicus/package.json CHANGELOG.md pnpm-lock.yaml package-lock.json yarn.lock bun.lock
     git commit -m "Begin v<next-version> development"

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,4 +18,4 @@ jobs:
             - run: pnpm install
             - run: pnpm run build
             - name: Publish to NPM
-              run: pnpm publish --no-git-checks --provenance
+              run: pnpm publish --no-git-checks --provenance ${{ github.event.release.prerelease && '--tag rc' || '' }}

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,8 +1,8 @@
 name: Publish
 
 on:
-    push:
-        tags: ['v*']
+    release:
+        types: [published]
 
 permissions:
     contents: read
@@ -11,12 +11,11 @@ permissions:
 jobs:
     publish:
         runs-on: ubuntu-latest
+        environment: Publish
         steps:
             - uses: actions/checkout@v4
             - uses: jdx/mise-action@v2
             - run: pnpm install
             - run: pnpm run build
             - name: Publish to NPM
-              env:
-                  NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
               run: pnpm publish --no-git-checks --provenance

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -8,4 +8,6 @@ Read @mise.toml and prefer Mise tasks over random shell expressions.
 
 ## Changelog
 
+Update CHANGELOG.md whenever you make any user-facing change, at commit or PR creation time. Phrase changes for a low-context reader who doesn't know the history of the project or of the change, and will probably read the release notes in isolation.
+
 When updating CHANGELOG.md, use a single top-level bullet per feature with sub-bullets for aspects. Focus on the final feature, not the sequence of events leading to it. Only document user-facing changes.

--- a/mise.toml
+++ b/mise.toml
@@ -150,17 +150,6 @@ for pm in npm yarn bun aube pnpm; do
 done
 """
 
-[tasks.release]
-description = "Build, test, and publish dependicus to NPM"
-depends = ["pnpm:build", "pnpm:test", "pnpm:typecheck"]
-interactive = true
-run = "pnpm publish"
-
-[tasks.prerelease]
-description = "Build, test, and publish a prerelease to NPM"
-depends = ["pnpm:build", "pnpm:test", "pnpm:typecheck"]
-interactive = true
-run = "pnpm publish --tag rc"
 
 [tasks.delete-node-modules]
 description = "Delete node_modules"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2721,15 +2721,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.13
-  resolution: "tar@npm:7.5.13"
+  version: 7.5.14
+  resolution: "tar@npm:7.5.14"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/5c65b8084799bde7a791593a1c1a45d3d6ee98182e3700b24c247b7b8f8654df4191642abbdb07ff25043d45dcff35620827c3997b88ae6c12040f64bed5076b
+  checksum: 10c0/619573265fa45295ff0b378f1097ab43187ab7b66e9483d3ad8f467c287674fb182ec878ef50a08761b8ab487863cb429902cf65fe361d47e330a95bfc4ca9e8
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Publishing now happens through the GitHub Actions workflow triggered by `gh release create`, using OIDC token exchange instead of a stored NPM_TOKEN secret. The publish workflow targets the `Publish` GitHub environment (which has required reviewers configured) and uses the `id-token: write` permission that was already in place. Prereleases automatically get the `rc` dist-tag.

The /release and /prerelease Claude Code commands now create the GitHub release (which triggers the publish workflow), then proceed to bump the version. The local `mise release` and `mise prerelease` tasks are removed since publishing is no longer done locally.