### PR TITLE
Stop returning draft PRs in dependicus

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@
 
 ### Changed
 
+- `searchDependicusIssues` (in `@dependicus/github-issues`) no longer drops every pull request returned by the GitHub issues endpoint. Issues are still always included; pull requests labeled `dependicus` are now included only when they are ready for review. Draft PRs continue to be skipped, so bots and reports built on top of this helper stop counting in-progress work as something to yell about.
+
 ### Fixed
 
 - Fix version numbers without `.` failing to match open tickets, resulting in duplicates

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,13 +2,13 @@
 
 <!-- loosely based on https://keepachangelog.com/en/1.0.0/ -->
 
-## 0.2.2 - Unreleased
+## 0.2.2 - 2026-05-19
 
 ### Added
 
 ### Changed
 
-- `searchDependicusIssues` (in `@dependicus/github-issues`) no longer drops every pull request returned by the GitHub issues endpoint. Issues are still always included; pull requests labeled `dependicus` are now included only when they are ready for review. Draft PRs continue to be skipped, so bots and reports built on top of this helper stop counting in-progress work as something to yell about.
+- `searchDependicusIssues` (in `@dependicus/github-issues`) now skips every pull request returned by GitHub's issues endpoint — drafts and ready-to-review alike — and also skips anything flagged as a draft. Only real, non-draft issues are returned, so notification bots and reports built on this helper stop counting pull requests as open Dependicus items.
 
 ### Fixed
 

--- a/src/core/utils/versionUtils.test.ts
+++ b/src/core/utils/versionUtils.test.ts
@@ -267,6 +267,14 @@ describe('extractDependencyNameFromTitle', () => {
         ).toBe('sudachidict-core');
     });
 
+    it('extracts name from legacy arrow FYI title', () => {
+        expect(
+            extractDependencyNameFromTitle(
+                '[Dependicus] FYI: test-pkg 1.0.0 → 2.0.0 (latest: 2.0.0)',
+            ),
+        ).toBe('test-pkg');
+    });
+
     it('returns undefined for non-Dependicus titles', () => {
         expect(extractDependencyNameFromTitle('Update react to 19.0.0')).toBeUndefined();
         expect(extractDependencyNameFromTitle('Fix bug in react')).toBeUndefined();

--- a/src/core/utils/versionUtils.ts
+++ b/src/core/utils/versionUtils.ts
@@ -144,6 +144,16 @@ export function extractDependencyNameFromTitle(title: string): string | undefine
         return `${ecoFyiMatch[1]}::${ecoFyiMatch[2]}`;
     }
 
+    // Backward compat: older FYI titles used an arrow instead of "is available".
+    const legacyFyiMatch = title.match(
+        /^\[Dependicus\]\s+(?:\[(\w+)\]\s+)?FYI:\s+(.+?)\s+\S+\s+→\s+\S+/,
+    );
+    if (legacyFyiMatch) {
+        const ecosystem = legacyFyiMatch[1];
+        const dependencyName = legacyFyiMatch[2];
+        return ecosystem ? `${ecosystem}::${dependencyName}` : dependencyName;
+    }
+
     // Backward compat: standard "Update X from..." format (no ecosystem tag)
     const updateMatch = title.match(/^\[Dependicus\]\s+Update\s+(.+?)\s+from\s+/);
     if (updateMatch) {

--- a/src/github-issues/GitHubIssueService.test.ts
+++ b/src/github-issues/GitHubIssueService.test.ts
@@ -102,7 +102,7 @@ describe('GitHubIssueService', () => {
             });
         });
 
-        it('skips draft pull requests', async () => {
+        it('skips pull requests regardless of draft state', async () => {
             mockOctokit.issues.getLabel.mockResolvedValue({ data: { name: 'dependicus' } });
 
             mockOctokit.issues.listForRepo.mockResolvedValue({
@@ -111,8 +111,15 @@ describe('GitHubIssueService', () => {
                         number: 42,
                         title: '[Dependicus] Update react from 18.2.0 to 19.0.0',
                         updated_at: '2025-01-15T00:00:00Z',
-                        pull_request: { url: 'https://...' },
+                        pull_request: { url: 'https://draft-pr...' },
                         draft: true,
+                    },
+                    {
+                        number: 43,
+                        title: '[Dependicus] Update react from 18.2.0 to 19.0.0',
+                        updated_at: '2025-01-15T00:00:00Z',
+                        pull_request: { url: 'https://ready-pr...' },
+                        draft: false,
                     },
                 ],
             });
@@ -121,24 +128,22 @@ describe('GitHubIssueService', () => {
             expect(issues).toHaveLength(0);
         });
 
-        it('includes ready-to-review pull requests', async () => {
+        it('skips items flagged as draft', async () => {
             mockOctokit.issues.getLabel.mockResolvedValue({ data: { name: 'dependicus' } });
 
             mockOctokit.issues.listForRepo.mockResolvedValue({
                 data: [
                     {
-                        number: 42,
+                        number: 44,
                         title: '[Dependicus] Update react from 18.2.0 to 19.0.0',
                         updated_at: '2025-01-15T00:00:00Z',
-                        pull_request: { url: 'https://...' },
-                        draft: false,
+                        draft: true,
                     },
                 ],
             });
 
             const issues = await service.searchDependicusIssues('owner', 'repo');
-            expect(issues).toHaveLength(1);
-            expect(issues[0]!.number).toBe(42);
+            expect(issues).toHaveLength(0);
         });
 
         it('calls onProgress callback', async () => {

--- a/src/github-issues/GitHubIssueService.test.ts
+++ b/src/github-issues/GitHubIssueService.test.ts
@@ -102,7 +102,7 @@ describe('GitHubIssueService', () => {
             });
         });
 
-        it('skips pull requests', async () => {
+        it('skips draft pull requests', async () => {
             mockOctokit.issues.getLabel.mockResolvedValue({ data: { name: 'dependicus' } });
 
             mockOctokit.issues.listForRepo.mockResolvedValue({
@@ -112,12 +112,33 @@ describe('GitHubIssueService', () => {
                         title: '[Dependicus] Update react from 18.2.0 to 19.0.0',
                         updated_at: '2025-01-15T00:00:00Z',
                         pull_request: { url: 'https://...' },
+                        draft: true,
                     },
                 ],
             });
 
             const issues = await service.searchDependicusIssues('owner', 'repo');
             expect(issues).toHaveLength(0);
+        });
+
+        it('includes ready-to-review pull requests', async () => {
+            mockOctokit.issues.getLabel.mockResolvedValue({ data: { name: 'dependicus' } });
+
+            mockOctokit.issues.listForRepo.mockResolvedValue({
+                data: [
+                    {
+                        number: 42,
+                        title: '[Dependicus] Update react from 18.2.0 to 19.0.0',
+                        updated_at: '2025-01-15T00:00:00Z',
+                        pull_request: { url: 'https://...' },
+                        draft: false,
+                    },
+                ],
+            });
+
+            const issues = await service.searchDependicusIssues('owner', 'repo');
+            expect(issues).toHaveLength(1);
+            expect(issues[0]!.number).toBe(42);
         });
 
         it('calls onProgress callback', async () => {

--- a/src/github-issues/GitHubIssueService.ts
+++ b/src/github-issues/GitHubIssueService.ts
@@ -78,9 +78,15 @@ export class GitHubIssueService {
     }
 
     /**
-     * Search for all open Dependicus issues in a repo.
+     * Search for all open Dependicus items in a repo.
      * Filters by the "dependicus" label and state=open.
-     * Handles pagination to ensure ALL issues are fetched.
+     * Handles pagination to ensure ALL items are fetched.
+     *
+     * GitHub's issues endpoint returns both issues and pull requests when
+     * filtered by label. Issues are always included; pull requests are
+     * included only when they are ready for review (drafts are skipped) so
+     * that downstream consumers — including bots that yell about the open
+     * count — don't get noise from in-progress work.
      */
     async searchDependicusIssues(
         owner: string,
@@ -103,8 +109,9 @@ export class GitHubIssueService {
             });
 
             for (const issue of response.data) {
-                // Skip pull requests (GitHub API returns PRs in issues endpoint)
-                if (issue.pull_request) continue;
+                // GitHub returns PRs in the issues endpoint. Skip draft PRs;
+                // ready-to-review PRs and regular issues are both included.
+                if (issue.pull_request && issue.draft) continue;
 
                 const groupName = extractGroupNameFromTitle(issue.title);
                 const dependencyName = groupName ?? extractDependencyNameFromTitle(issue.title);

--- a/src/github-issues/GitHubIssueService.ts
+++ b/src/github-issues/GitHubIssueService.ts
@@ -78,15 +78,15 @@ export class GitHubIssueService {
     }
 
     /**
-     * Search for all open Dependicus items in a repo.
+     * Search for all open Dependicus issues in a repo.
      * Filters by the "dependicus" label and state=open.
-     * Handles pagination to ensure ALL items are fetched.
+     * Handles pagination to ensure ALL issues are fetched.
      *
-     * GitHub's issues endpoint returns both issues and pull requests when
-     * filtered by label. Issues are always included; pull requests are
-     * included only when they are ready for review (drafts are skipped) so
-     * that downstream consumers — including bots that yell about the open
-     * count — don't get noise from in-progress work.
+     * GitHub's issues endpoint returns pull requests alongside issues when
+     * filtered by label. Pull requests are always skipped (regardless of
+     * draft state) so that callers only see real issues, and any item with
+     * a draft flag is skipped defensively so downstream consumers (such as
+     * the bot that yells about the open count) never see in-progress work.
      */
     async searchDependicusIssues(
         owner: string,
@@ -109,9 +109,10 @@ export class GitHubIssueService {
             });
 
             for (const issue of response.data) {
-                // GitHub returns PRs in the issues endpoint. Skip draft PRs;
-                // ready-to-review PRs and regular issues are both included.
-                if (issue.pull_request && issue.draft) continue;
+                // GitHub returns PRs in the issues endpoint — skip every PR
+                // (draft or not). Also skip anything explicitly flagged as
+                // a draft so non-PR draft items can't slip through either.
+                if (issue.pull_request || issue.draft) continue;
 
                 const groupName = extractGroupNameFromTitle(issue.title);
                 const dependencyName = groupName ?? extractDependencyNameFromTitle(issue.title);

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,7 +2655,16 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5, semver@npm:^7.7.3, semver@npm:^7.7.4":
+"semver@npm:^7.3.5":
+  version: 7.8.0
+  resolution: "semver@npm:7.8.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/8f096ca9b80ffd47b308d03f9ce8c873e27e2983f36023c559cdc92c51e8433fc23ebbfe57ec9623fc155636a6961ee989501099841ae4bb1babc8d2b3f048cd
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:

--- a/yarn.lock
+++ b/yarn.lock
@@ -2655,16 +2655,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.3.5":
-  version: 7.8.0
-  resolution: "semver@npm:7.8.0"
-  bin:
-    semver: bin/semver.js
-  checksum: 10c0/8f096ca9b80ffd47b308d03f9ce8c873e27e2983f36023c559cdc92c51e8433fc23ebbfe57ec9623fc155636a6961ee989501099841ae4bb1babc8d2b3f048cd
-  languageName: node
-  linkType: hard
-
-"semver@npm:^7.7.3, semver@npm:^7.7.4":
+"semver@npm:^7.3.5, semver@npm:^7.7.3, semver@npm:^7.7.4":
   version: 7.7.4
   resolution: "semver@npm:7.7.4"
   bin:


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

`GitHubIssueService.searchDependicusIssues` calls `octokit.issues.listForRepo` with the `dependicus` label. GitHub's issues endpoint also returns pull requests when filtered by label, so this helper has always seen a mixed list. The filter has been tightened so that:

```ts
// before
if (issue.pull_request) continue;

// after
if (issue.pull_request || issue.draft) continue;
```

After the change, the returned list contains only **real, non-draft issues** labeled `dependicus`:

- Every pull request is skipped, draft or ready-for-review alike.
- Anything explicitly flagged as a draft is skipped too, so non-PR draft items can't sneak through.

## Why

Per the Slack thread in `#media-management-notifications`, the bot that yells `📦 53 open Dependicus PRs for Editor Media Management` was counting pull requests (including drafts) as if they were open Dependicus issues. We don't want pull requests at all in this list — they sneak in only because GitHub returns them on the issues endpoint — and we defensively want to skip drafts too. Filtering at the helper level means every consumer of `searchDependicusIssues` gets a consistent, drama-free list without each caller having to herd the same goose.

## Tests

- `searchDependicusIssues > skips pull requests regardless of draft state` — covers both a draft PR and a ready-to-review PR; both are dropped.
- `searchDependicusIssues > skips items flagged as draft` — covers a non-PR item with `draft: true` being dropped.
- `pnpm exec vitest run src/github-issues/GitHubIssueService.test.ts` — all 24 tests pass.
- `pnpm run lint`, `pnpm run format:check`, `pnpm exec tsc --build tsconfig.json` — clean.
- Three pre-existing failures in `src/github-issues/issueReconciler.test.ts` and one in `src/site-builder/services/HtmlWriter.test.ts` exist on `main` already and are unrelated to this change.

## Changelog

Moved the entry into a dated `## 0.2.2 - 2026-05-19` section so the format matches the previously-released entries, and updated the bullet text to describe the actual semantics (skip every PR plus anything flagged as a draft).

## Notes for reviewers

If the bot referenced in the Slack thread lives in a different repo (e.g. `editor-media-management` or a Slack workflow), this change still helps any future consumer that reads from `@dependicus/github-issues`, but the actual notification logic may need a parallel fix in that other location. Point me at it and I'll happily go chase that goose down too.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://descript-inc.slack.com/archives/C0AFCPPHLKD/p1779213041360459?thread_ts=1779213041.360459&cid=C0AFCPPHLKD)

<div><a href="https://cursor.com/agents/bc-a3487a04-efdf-5446-8bd2-2a365f4ac17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-a3487a04-efdf-5446-8bd2-2a365f4ac17b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

