### PR TITLE
Stop counting draft PRs as open Dependicus items for review

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@
 
 ### Changed
 
-- `searchDependicusIssues` (in `@dependicus/github-issues`) now skips every pull request returned by GitHub's issues endpoint — drafts and ready-to-review alike — and also skips anything flagged as a draft. Only real, non-draft issues are returned, so notification bots and reports built on this helper stop counting pull requests as open Dependicus items.
+- `searchDependicusIssues` (in `@dependicus/github-issues`) now treats draft pull requests as not yet open for review and excludes them from results, while ready-for-review pull requests are returned alongside regular issues. Each returned entry carries an `isPullRequest` boolean so notification bots can count open Dependicus items accurately — drafts no longer pad the total — and the reconciler can avoid mutating pull requests. Anything explicitly flagged as a draft (PR or otherwise) is still skipped defensively.
 
 ### Fixed
 

--- a/src/github-issues/GitHubIssueService.test.ts
+++ b/src/github-issues/GitHubIssueService.test.ts
@@ -99,10 +99,11 @@ describe('GitHubIssueService', () => {
                 dependencyName: 'react',
                 isGroup: false,
                 updatedAt: '2025-01-15T00:00:00Z',
+                isPullRequest: false,
             });
         });
 
-        it('skips pull requests regardless of draft state', async () => {
+        it('skips draft PRs and includes ready-for-review PRs flagged as pull requests', async () => {
             mockOctokit.issues.getLabel.mockResolvedValue({ data: { name: 'dependicus' } });
 
             mockOctokit.issues.listForRepo.mockResolvedValue({
@@ -125,7 +126,27 @@ describe('GitHubIssueService', () => {
             });
 
             const issues = await service.searchDependicusIssues('owner', 'repo');
-            expect(issues).toHaveLength(0);
+            expect(issues).toHaveLength(1);
+            expect(issues[0]!.number).toBe(43);
+            expect(issues[0]!.isPullRequest).toBe(true);
+        });
+
+        it('flags non-PR matches as not being a pull request', async () => {
+            mockOctokit.issues.getLabel.mockResolvedValue({ data: { name: 'dependicus' } });
+
+            mockOctokit.issues.listForRepo.mockResolvedValue({
+                data: [
+                    {
+                        number: 7,
+                        title: '[Dependicus] Update react from 18.2.0 to 19.0.0',
+                        updated_at: '2025-01-15T00:00:00Z',
+                    },
+                ],
+            });
+
+            const issues = await service.searchDependicusIssues('owner', 'repo');
+            expect(issues).toHaveLength(1);
+            expect(issues[0]!.isPullRequest).toBe(false);
         });
 
         it('skips items flagged as draft', async () => {

--- a/src/github-issues/GitHubIssueService.ts
+++ b/src/github-issues/GitHubIssueService.ts
@@ -5,7 +5,7 @@ const DEPENDICUS_LABEL_NAME = 'dependicus';
 const TITLE_PREFIX = '[Dependicus]';
 
 export interface DependicusIssue {
-    /** GitHub issue number */
+    /** GitHub issue number (or pull request number — they share a numbering scheme) */
     number: number;
     title: string;
     /** Issue body (markdown description) */
@@ -21,6 +21,13 @@ export interface DependicusIssue {
     isGroup: boolean;
     /** ISO date string when the issue was last updated */
     updatedAt: string;
+    /**
+     * True when this entry is a pull request. Drafts are filtered out by
+     * `searchDependicusIssues`, so any PR here is ready-for-review. PRs are
+     * surfaced so notification bots can count open Dependicus items
+     * accurately, but the reconciler must avoid mutating them.
+     */
+    isPullRequest: boolean;
 }
 
 export interface CreateIssueParams {
@@ -78,15 +85,18 @@ export class GitHubIssueService {
     }
 
     /**
-     * Search for all open Dependicus issues in a repo.
+     * Search for all open Dependicus items in a repo.
      * Filters by the "dependicus" label and state=open.
-     * Handles pagination to ensure ALL issues are fetched.
+     * Handles pagination to ensure ALL items are fetched.
      *
      * GitHub's issues endpoint returns pull requests alongside issues when
-     * filtered by label. Pull requests are always skipped (regardless of
-     * draft state) so that callers only see real issues, and any item with
-     * a draft flag is skipped defensively so downstream consumers (such as
-     * the bot that yells about the open count) never see in-progress work.
+     * filtered by label. Draft pull requests are skipped because a draft is
+     * explicitly not "open for review" — the bot that yells about the open
+     * Dependicus count shouldn't honk at half-finished work. Ready-for-review
+     * pull requests and regular issues are both returned (with
+     * `isPullRequest` set accordingly) so they can be counted as legitimately
+     * open. Anything flagged as a draft (PR or otherwise) is also skipped
+     * defensively.
      */
     async searchDependicusIssues(
         owner: string,
@@ -109,10 +119,10 @@ export class GitHubIssueService {
             });
 
             for (const issue of response.data) {
-                // GitHub returns PRs in the issues endpoint — skip every PR
-                // (draft or not). Also skip anything explicitly flagged as
-                // a draft so non-PR draft items can't slip through either.
-                if (issue.pull_request || issue.draft) continue;
+                // Draft items (PRs or otherwise) are not open for review yet,
+                // so they don't count toward the open total. Non-draft PRs
+                // and regular issues both flow through.
+                if (issue.draft) continue;
 
                 const groupName = extractGroupNameFromTitle(issue.title);
                 const dependencyName = groupName ?? extractDependencyNameFromTitle(issue.title);
@@ -125,6 +135,7 @@ export class GitHubIssueService {
                     dependencyName,
                     isGroup: groupName !== undefined,
                     updatedAt: issue.updated_at,
+                    isPullRequest: Boolean(issue.pull_request),
                 });
             }
 
@@ -174,6 +185,7 @@ export class GitHubIssueService {
                 dependencyName: extractedName,
                 isGroup: groupName !== undefined,
                 updatedAt: item.updated_at,
+                isPullRequest: false,
             };
         }
 

--- a/src/github-issues/issueReconciler.ts
+++ b/src/github-issues/issueReconciler.ts
@@ -472,18 +472,24 @@ export async function reconcileGitHubIssues(
     );
     process.stderr.write(`Found ${existingIssues.length} existing issues\n`);
 
-    // Build maps for deduplication
+    // Build maps for deduplication. Pull requests (always ready-for-review at
+    // this point — drafts are filtered upstream) are recorded by title so we
+    // don't create a duplicate issue when an agent has already opened a PR,
+    // but they're excluded from the by-dependency map so the reconciler never
+    // mutates them like an issue (an `octokit.issues.update` against a PR
+    // number would clobber the PR's title and body).
     const existingIssuesByDependency = new Map<string, DependicusIssue>();
     const existingIssuesByTitle = new Set<string>();
     const duplicateIssues: DependicusIssue[] = [];
 
     for (const issue of existingIssues) {
+        existingIssuesByTitle.add(issue.title);
+        if (issue.isPullRequest) continue;
         if (!existingIssuesByDependency.has(issue.dependencyName)) {
             existingIssuesByDependency.set(issue.dependencyName, issue);
         } else {
             duplicateIssues.push(issue);
         }
-        existingIssuesByTitle.add(issue.title);
     }
 
     // Close duplicate issues proactively

--- a/yarn.lock
+++ b/yarn.lock
@@ -2656,11 +2656,11 @@ __metadata:
   linkType: hard
 
 "semver@npm:^7.3.5":
-  version: 7.8.0
-  resolution: "semver@npm:7.8.0"
+  version: 7.8.1
+  resolution: "semver@npm:7.8.1"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/8f096ca9b80ffd47b308d03f9ce8c873e27e2983f36023c559cdc92c51e8433fc23ebbfe57ec9623fc155636a6961ee989501099841ae4bb1babc8d2b3f048cd
+  checksum: 10c0/92d6871d6347e1f99d0ba396a70f2545ccf2a032cda3d378fa0699edf7506b5c6d266aed55c8b88e72bd91a30d2351e4f39db479375374430fcdc4b58f4e3c1a
   languageName: node
   linkType: hard
 
@@ -2975,9 +2975,9 @@ __metadata:
   linkType: hard
 
 "undici@npm:^6.25.0":
-  version: 6.25.0
-  resolution: "undici@npm:6.25.0"
-  checksum: 10c0/2597cc6689bdb02c210c557b1f85febbfda65becae6e6fc1061508e2f33734d25207f81cd8af56ada9956329eb3a7bd7431e87dcfeceba20ee87059b57dcf985
+  version: 6.26.0
+  resolution: "undici@npm:6.26.0"
+  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What's changing

The previous pass over-corrected: `searchDependicusIssues` was changed to drop *every* pull request returned by GitHub's issues endpoint, draft or not. That made the notification bot's job impossible — it couldn't see the open Dependicus PRs that legitimately needed review, and it kept honking `:package: 54 open Dependicus PRs for Editor Media Management` because the count was still being padded by drafts coming in from elsewhere.

This PR puts `searchDependicusIssues` back where it belongs:

- **Skip draft PRs only.** A draft is explicitly not "open for review", so it shouldn't count.
- **Return ready-for-review PRs alongside regular issues.** Each entry now carries an `isPullRequest` boolean so callers can tell them apart.
- **Still skip anything flagged as a draft** (PR or otherwise) defensively, so non-PR draft items can't sneak through.

The reconciler picks up the new flag and uses it to keep treating a PR title as "something already exists, don't create a duplicate", while never mutating the PR via `octokit.issues.update` (which would clobber the PR's title and body, since GitHub gives PRs and issues a shared numbering scheme).

## Tests

- New test asserts a draft PR is dropped while a ready-for-review PR is returned with `isPullRequest: true`.
- New test asserts non-PR matches are flagged with `isPullRequest: false`.
- Existing tests updated for the new field.
- Full suite passes (the unrelated `HtmlWriter.test.ts` failure on `browser-bundle.asset.js` reproduces on `main` without my changes — it needs a build first).

## Waterfowl moment

The goose finally stops honking at perfectly good ducks paddling in the review pond. Only the ducklings still tucked under the wing get left alone.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://descript-inc.slack.com/archives/C0AFCPPHLKD/p1779818658724089?thread_ts=1779818658.724089&cid=C0AFCPPHLKD)

<div><a href="https://cursor.com/agents/bc-759a0c06-94fc-5967-9d5d-54524549f07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-759a0c06-94fc-5967-9d5d-54524549f07c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

