### PR TITLE
Stop setting issue due dates that are already in the past

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@
 ### Fixed
 
 - Fix version numbers without `.` failing to match open tickets, resulting in duplicates
+- Issues are no longer given a due date that is already in the past
+    - When a dependency passed its SLA deadline before Dependicus ever filed an issue, the issue is now created without a due date instead of being filed already overdue. This covers both the Linear due date field and the `(due YYYY-MM-DD)` suffix on GitHub issue titles.
+    - A due date already recorded on an existing issue is left alone, so deadlines set on earlier runs stay visible after they pass.
 
 ### Removed
 

--- a/docs/docs/githubissues.md
+++ b/docs/docs/githubissues.md
@@ -71,6 +71,8 @@ dependicus make-github-issues --cooldown-days 5 --rate-limit-days 14 --no-new-is
 
 Since GitHub Issues have no native due date field, the due date is appended to the issue title: `Update react 18.2.0 → 19.0.0 (due 2025-03-15)`. The due date also appears in the issue body.
 
+A due date is only added when it is still upcoming. If a dependency already blew through its threshold before an issue existed, the issue is filed without a due date rather than being born overdue — the body still reports how many days overdue the dependency is. A due date already present on an issue is kept once it passes, so deadlines set on earlier runs stay visible.
+
 ## Token resolution
 
 The `make-github-issues` command looks for `GITHUB_TOKEN` in the environment first. If not set, it falls back to `gh auth token` (the GitHub CLI). This means local development works without exporting a token if you've already run `gh auth login`.

--- a/docs/docs/linearissues.md
+++ b/docs/docs/linearissues.md
@@ -61,6 +61,12 @@ void dependicusCli({
 }).run(process.argv);
 ```
 
+## Due dates
+
+Issues created from a `dueDate` policy get their Linear due date from the SLA threshold: the date the required version was published plus the policy's `thresholdDays`.
+
+A due date is only set when it is still upcoming. If a dependency already blew through its threshold before an issue existed, the issue is created without a due date rather than being born overdue — the description still reports how many days overdue the dependency is. A due date already set on an issue is kept once it passes, so deadlines set on earlier runs stay visible.
+
 ## CLI flags
 
 The `make-linear-issues` command accepts these flags in addition to `--dry-run`, `--json-file`, and `--linear-team-id`:

--- a/src/core/index.ts
+++ b/src/core/index.ts
@@ -49,6 +49,7 @@ export {
     buildGroupTicketTitle,
     findFirstVersionOfType,
     calculateDueDate,
+    isDueDateInPast,
     isWithinCooldown,
     findLatestWithinMajor,
     findLatestWithinMinor,

--- a/src/core/utils/versionUtils.test.ts
+++ b/src/core/utils/versionUtils.test.ts
@@ -12,6 +12,7 @@ import {
     buildGroupTicketTitle,
     findFirstVersionOfType,
     calculateDueDate,
+    isDueDateInPast,
     isWithinCooldown,
     findLatestWithinMajor,
     isWithinNotificationRateLimit,
@@ -448,6 +449,26 @@ describe('calculateDueDate', () => {
 
         expect(dueDate.getFullYear()).toBe(2024);
         expect(dueDate.getMonth()).toBe(11); // December
+    });
+});
+
+describe('isDueDateInPast', () => {
+    const now = new Date('2026-08-31T12:00:00Z');
+
+    it('returns true for a due date before today', () => {
+        expect(isDueDateInPast(new Date('2026-08-30'), now)).toBe(true);
+    });
+
+    it('returns false for a due date later today', () => {
+        expect(isDueDateInPast(new Date('2026-08-31T23:00:00Z'), now)).toBe(false);
+    });
+
+    it('returns false for a due date earlier today', () => {
+        expect(isDueDateInPast(new Date('2026-08-31T00:00:00Z'), now)).toBe(false);
+    });
+
+    it('returns false for a future due date', () => {
+        expect(isDueDateInPast(new Date('2026-09-01'), now)).toBe(false);
     });
 });
 

--- a/src/core/utils/versionUtils.ts
+++ b/src/core/utils/versionUtils.ts
@@ -316,6 +316,20 @@ export function calculateDueDate(
 }
 
 /**
+ * Check whether a due date has already passed.
+ *
+ * Compared by calendar day in UTC, the same way due dates are serialized onto
+ * issues, so a due date of today counts as still upcoming.
+ */
+export function isDueDateInPast(dueDate: Date, now: Date = new Date()): boolean {
+    return startOfUtcDay(dueDate) < startOfUtcDay(now);
+}
+
+function startOfUtcDay(date: Date): number {
+    return Date.UTC(date.getUTCFullYear(), date.getUTCMonth(), date.getUTCDate());
+}
+
+/**
  * Check if a version is within the cooldown period.
  * Returns true if the first required version was published less than cooldownDays ago.
  */

--- a/src/github-issues/issueReconciler.test.ts
+++ b/src/github-issues/issueReconciler.test.ts
@@ -53,15 +53,31 @@ function makeVersion(overrides: Partial<DependencyVersion> = {}): DependencyVers
     };
 }
 
-function makeStore(dependencyName: string = 'test-pkg', version: string = '1.0.0'): FactStore {
+/** ISO date (YYYY-MM-DD) for a day in the past, relative to when the test runs. */
+function daysAgo(days: number): string {
+    return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().split('T')[0]!;
+}
+
+/** Versions between 1.0.0 and 2.0.0 where the major update landed `days` ago. */
+function majorPublishedDaysAgo(days: number): PackageVersionInfo[] {
+    return [
+        {
+            version: '2.0.0',
+            publishDate: daysAgo(days),
+            isPrerelease: false,
+            registryUrl: 'https://www.npmjs.com/package/test-pkg/v/2.0.0',
+        },
+    ];
+}
+
+function makeStore(
+    dependencyName: string = 'test-pkg',
+    version: string = '1.0.0',
+    versionsBetween: PackageVersionInfo[] = defaultVersionsBetween,
+): FactStore {
     const root = new RootFactStore();
     const scoped = root.scoped('npm');
-    scoped.setVersionFact(
-        dependencyName,
-        version,
-        FactKeys.VERSIONS_BETWEEN,
-        defaultVersionsBetween,
-    );
+    scoped.setVersionFact(dependencyName, version, FactKeys.VERSIONS_BETWEEN, versionsBetween);
     scoped.setVersionFact(dependencyName, version, FactKeys.DESCRIPTION, 'A test package');
     return root;
 }
@@ -296,7 +312,7 @@ describe('reconcileGitHubIssues', () => {
         const deps: DirectDependency[] = [
             { name: 'test-pkg', ecosystem: 'npm', versions: [makeVersion()] },
         ];
-        const store = makeStore();
+        const store = makeStore('test-pkg', '1.0.0', majorPublishedDaysAgo(10));
 
         const result = await reconcileGitHubIssues(deps, store, baseConfig, () =>
             makeSpec({
@@ -309,6 +325,57 @@ describe('reconcileGitHubIssues', () => {
         expect(result.created).toBe(1);
         const createCall = mockOctokit.issues.create.mock.calls[0]![0];
         expect(createCall.title).toContain('(due ');
+    });
+
+    it('omits the due date from the title when it has already passed', async () => {
+        setupMocks();
+
+        const deps: DirectDependency[] = [
+            { name: 'test-pkg', ecosystem: 'npm', versions: [makeVersion()] },
+        ];
+        // Published well over the 360-day threshold ago, so the due date has passed
+        const store = makeStore('test-pkg', '1.0.0', majorPublishedDaysAgo(800));
+
+        const result = await reconcileGitHubIssues(deps, store, baseConfig, () =>
+            makeSpec({
+                policy: { type: 'dueDate' },
+                daysOverdue: 440,
+                thresholdDays: 360,
+            }),
+        );
+
+        expect(result.created).toBe(1);
+        const createCall = mockOctokit.issues.create.mock.calls[0]![0];
+        expect(createCall.title).not.toContain('(due ');
+        expect(createCall.body).not.toContain('**Due date:**');
+    });
+
+    it('keeps the due date an existing issue already has after it passes', async () => {
+        setupMocks([
+            {
+                number: 42,
+                title: '[Dependicus] [npm] Update test-pkg from 1.0.0 to 2.0.0 (due 2024-05-06)',
+                updated_at: '2024-01-01T00:00:00Z',
+            },
+        ]);
+
+        const deps: DirectDependency[] = [
+            { name: 'test-pkg', ecosystem: 'npm', versions: [makeVersion()] },
+        ];
+        const store = makeStore('test-pkg', '1.0.0', majorPublishedDaysAgo(800));
+
+        const result = await reconcileGitHubIssues(deps, store, baseConfig, () =>
+            makeSpec({
+                policy: { type: 'dueDate' },
+                daysOverdue: 440,
+                thresholdDays: 360,
+            }),
+        );
+
+        expect(result.created).toBe(0);
+        const updateCall = mockOctokit.issues.update.mock.calls[0]![0];
+        expect(updateCall.title).toContain('(due 2024-05-06)');
+        expect(updateCall.body).toContain('**Due date:** 2024-05-06');
     });
 
     it('includes assignees when assignment is assign type', async () => {

--- a/src/github-issues/issueReconciler.ts
+++ b/src/github-issues/issueReconciler.ts
@@ -16,6 +16,7 @@ import {
     buildGroupTicketTitle,
     findFirstVersionOfType,
     calculateDueDate,
+    isDueDateInPast,
     isWithinCooldown,
     isWithinNotificationRateLimit,
     hasMajorVersionSinceLastUpdate,
@@ -238,6 +239,28 @@ function aggregatePolicy(
 /** Format a due date for inclusion in an issue title. */
 function formatDueDateForTitle(dueDate: Date): string {
     return dueDate.toISOString().split('T')[0]!;
+}
+
+/** Read back the due date a previous run appended to an issue title. */
+function extractDueDateFromTitle(title: string): string | undefined {
+    return /\(due (\d{4}-\d{2}-\d{2})\)/.exec(title)?.[1];
+}
+
+/**
+ * Pick the due date to show on an issue.
+ *
+ * A deadline that has already passed is not worth showing — an issue would be
+ * filed overdue on day one — so it is dropped. An issue that already carries a
+ * due date keeps it, so a deadline set on an earlier run stays visible once the
+ * date passes.
+ */
+function resolveDueDate(
+    calculatedDueDate: Date | undefined,
+    existingTitle?: string | undefined,
+): string | undefined {
+    if (!calculatedDueDate) return undefined;
+    if (!isDueDateInPast(calculatedDueDate)) return formatDueDateForTitle(calculatedDueDate);
+    return existingTitle ? extractDueDateFromTitle(existingTitle) : undefined;
 }
 
 export async function reconcileGitHubIssues(
@@ -540,7 +563,7 @@ export async function reconcileGitHubIssues(
         const notificationsOnly = isFyiPolicy(dep.policy);
 
         // Calculate due date (undefined for fyi dependencies)
-        const dueDate =
+        const calculatedDueDate =
             dep.worstCompliance.thresholdDays !== undefined
                 ? calculateDueDate(
                       version.version,
@@ -551,7 +574,7 @@ export async function reconcileGitHubIssues(
                   )
                 : undefined;
 
-        const dueDateStr = dueDate ? formatDueDateForTitle(dueDate) : undefined;
+        const dueDateStr = resolveDueDate(calculatedDueDate, existingIssue?.title);
 
         // Build title and description
         const effectiveLatestVersion = dep.targetVersion ?? version.latestVersion;
@@ -793,7 +816,7 @@ export async function reconcileGitHubIssues(
             }
         }
 
-        const dueDateStr = earliestDueDate ? formatDueDateForTitle(earliestDueDate) : undefined;
+        const dueDateStr = resolveDueDate(earliestDueDate, existingIssue?.title);
 
         let title = buildGroupTicketTitle(group.groupName, group.dependencies.length, {
             notificationsOnly: groupNotificationsOnly,

--- a/src/linear/issueReconciler.test.ts
+++ b/src/linear/issueReconciler.test.ts
@@ -53,6 +53,23 @@ const defaultVersionsBetween: PackageVersionInfo[] = [
     },
 ];
 
+/** ISO date (YYYY-MM-DD) for a day in the past, relative to when the test runs. */
+function daysAgo(days: number): string {
+    return new Date(Date.now() - days * 24 * 60 * 60 * 1000).toISOString().split('T')[0]!;
+}
+
+/** Versions between 1.0.0 and 2.0.0 where the major update landed `days` ago. */
+function majorPublishedDaysAgo(days: number): PackageVersionInfo[] {
+    return [
+        {
+            version: '2.0.0',
+            publishDate: daysAgo(days),
+            isPrerelease: false,
+            registryUrl: 'https://www.npmjs.com/package/test-pkg/v/2.0.0',
+        },
+    ];
+}
+
 function testTeamId(dependencyName: string): string | undefined {
     if (dependencyName.includes('unknown-team')) return undefined;
     return 'linear-team-123';
@@ -260,6 +277,95 @@ describe('reconcileIssues', () => {
         const result = await reconcileIssues(deps, store, defaultConfig, testGetLinearIssueSpec);
         expect(result.updated).toBe(1);
         expect(result.created).toBe(0);
+    });
+
+    describe('due dates', () => {
+        const mockState = { type: 'unstarted', name: 'Todo' };
+
+        function mockExistingIssue(dueDate: string | undefined) {
+            mockClient.issues.mockResolvedValue({
+                nodes: [
+                    {
+                        id: 'issue-1',
+                        identifier: 'TEST-50',
+                        title: '[Dependicus] Update test-pkg from 1.0.0 to 2.0.0',
+                        dueDate,
+                        updatedAt: new Date('2024-01-01'),
+                        state: Promise.resolve(mockState),
+                    },
+                ],
+                pageInfo: { hasNextPage: false, endCursor: undefined },
+            });
+        }
+
+        it('sets a due date that is still upcoming', async () => {
+            const v = makeVersion();
+            populateFacts(store, 'test-pkg', v, { versionsBetween: majorPublishedDaysAgo(10) });
+            const deps: DirectDependency[] = [makeDep('test-pkg', [v])];
+
+            await reconcileIssues(
+                deps,
+                store,
+                { ...defaultConfig, dryRun: false, cooldownDays: 0 },
+                testGetLinearIssueSpec,
+            );
+
+            const createArg = mockClient.createIssue.mock.calls[0]![0];
+            expect(createArg.dueDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+        });
+
+        it('creates issues without a due date once the deadline has passed', async () => {
+            const v = makeVersion();
+            // The 360-day major threshold ran out long ago for this dependency
+            populateFacts(store, 'test-pkg', v, { versionsBetween: majorPublishedDaysAgo(800) });
+            const deps: DirectDependency[] = [makeDep('test-pkg', [v])];
+
+            await reconcileIssues(
+                deps,
+                store,
+                { ...defaultConfig, dryRun: false },
+                testGetLinearIssueSpec,
+            );
+
+            const createArg = mockClient.createIssue.mock.calls[0]![0];
+            expect(createArg.dueDate).toBeUndefined();
+        });
+
+        it('leaves the due date an existing issue already has in place', async () => {
+            mockExistingIssue('2025-06-01');
+
+            const v = makeVersion();
+            populateFacts(store, 'test-pkg', v, { versionsBetween: majorPublishedDaysAgo(800) });
+            const deps: DirectDependency[] = [makeDep('test-pkg', [v])];
+
+            await reconcileIssues(
+                deps,
+                store,
+                { ...defaultConfig, dryRun: false },
+                testGetLinearIssueSpec,
+            );
+
+            const [, updateArg] = mockClient.updateIssue.mock.calls[0]!;
+            expect(updateArg.dueDate).toBe('2025-06-01');
+        });
+
+        it('does not add a past due date to an existing issue without one', async () => {
+            mockExistingIssue(undefined);
+
+            const v = makeVersion();
+            populateFacts(store, 'test-pkg', v, { versionsBetween: majorPublishedDaysAgo(800) });
+            const deps: DirectDependency[] = [makeDep('test-pkg', [v])];
+
+            await reconcileIssues(
+                deps,
+                store,
+                { ...defaultConfig, dryRun: false },
+                testGetLinearIssueSpec,
+            );
+
+            const [, updateArg] = mockClient.updateIssue.mock.calls[0]!;
+            expect(updateArg.dueDate).toBeNull();
+        });
     });
 
     it('closes issues for packages that are now compliant', async () => {

--- a/src/linear/issueReconciler.ts
+++ b/src/linear/issueReconciler.ts
@@ -16,6 +16,7 @@ import {
     buildGroupTicketTitle,
     findFirstVersionOfType,
     calculateDueDate,
+    isDueDateInPast,
     isWithinCooldown,
     isWithinNotificationRateLimit,
     hasMajorVersionSinceLastUpdate,
@@ -117,6 +118,24 @@ function policyRateLimitDays(policy: LinearPolicy, configDefault?: number): numb
 /** Whether a policy represents a notifications-only / FYI package. */
 function isFyiPolicy(policy: LinearPolicy): boolean {
     return policy.type === 'fyi';
+}
+
+/**
+ * Pick the due date to write to an issue.
+ *
+ * A deadline that has already passed is not worth setting — an issue would be
+ * filed overdue on day one — so it is dropped. An issue that already carries a
+ * due date keeps it, so a deadline set on an earlier run stays visible once the
+ * date passes.
+ */
+function resolveDueDate(
+    calculatedDueDate: Date | undefined,
+    existingDueDate?: string | undefined,
+): Date | undefined {
+    if (!calculatedDueDate || !isDueDateInPast(calculatedDueDate)) {
+        return calculatedDueDate;
+    }
+    return existingDueDate ? new Date(existingDueDate) : undefined;
 }
 
 /**
@@ -536,7 +555,7 @@ export async function reconcileIssues(
         const notificationsOnly = isFyiPolicy(dep.policy);
 
         // Calculate due date (undefined for fyi dependencies)
-        const dueDate =
+        const calculatedDueDate =
             dep.worstCompliance.thresholdDays !== undefined
                 ? calculateDueDate(
                       version.version,
@@ -642,7 +661,7 @@ export async function reconcileIssues(
                 {
                     title,
                     description,
-                    dueDate,
+                    dueDate: resolveDueDate(calculatedDueDate, existingIssue.dueDate),
                 },
                 existingIssue.identifier,
             );
@@ -704,7 +723,7 @@ export async function reconcileIssues(
             if (closedIssue) {
                 await linearService.reopenIssue(
                     closedIssue.id,
-                    { title, description, dueDate },
+                    { title, description, dueDate: resolveDueDate(calculatedDueDate) },
                     closedIssue.identifier,
                 );
 
@@ -742,7 +761,7 @@ export async function reconcileIssues(
                 dependencyName: dep.name,
                 title,
                 teamId: dep.teamId,
-                dueDate,
+                dueDate: resolveDueDate(calculatedDueDate),
                 description,
                 delegateId,
             });
@@ -845,7 +864,7 @@ export async function reconcileIssues(
                 {
                     title,
                     description,
-                    dueDate: earliestDueDate,
+                    dueDate: resolveDueDate(earliestDueDate, existingIssue.dueDate),
                 },
                 existingIssue.identifier,
             );
@@ -894,7 +913,7 @@ export async function reconcileIssues(
             if (closedIssue) {
                 await linearService.reopenIssue(
                     closedIssue.id,
-                    { title, description, dueDate: earliestDueDate },
+                    { title, description, dueDate: resolveDueDate(earliestDueDate) },
                     closedIssue.identifier,
                 );
 
@@ -931,7 +950,7 @@ export async function reconcileIssues(
                 dependencyName: group.groupName,
                 title,
                 teamId: group.teamId,
-                dueDate: earliestDueDate,
+                dueDate: resolveDueDate(earliestDueDate),
                 description,
             });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -425,14 +425,14 @@ __metadata:
   linkType: hard
 
 "@napi-rs/wasm-runtime@npm:^1.1.1":
-  version: 1.1.5
-  resolution: "@napi-rs/wasm-runtime@npm:1.1.5"
+  version: 1.2.3
+  resolution: "@napi-rs/wasm-runtime@npm:1.2.3"
   dependencies:
-    "@tybys/wasm-util": "npm:^0.10.2"
+    "@tybys/wasm-util": "npm:^0.10.3"
   peerDependencies:
-    "@emnapi/core": ^1.7.1
-    "@emnapi/runtime": ^1.7.1
-  checksum: 10c0/727f2b6ae0e68bbe5d39aeb68aa6f183314e9f03dc50bb55a962849535b2db53ecc3fbf1554d8656a54488a608df5a2634670595cf5874dc4af2ee59f817c65d
+    "@emnapi/core": ^1.7.1 || ^2.0.0-alpha.4
+    "@emnapi/runtime": ^1.7.1 || ^2.0.0-alpha.4
+  checksum: 10c0/6da0a4bf9df79e9abfb3e3d462f6a5d42889be39426040038c9dd5925865585d7dbd06dd439c2ffc20f49ef2751412da5bd748cfb3c5b049142d72c0550f6f79
   languageName: node
   linkType: hard
 
@@ -1230,12 +1230,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tybys/wasm-util@npm:^0.10.2":
-  version: 0.10.2
-  resolution: "@tybys/wasm-util@npm:0.10.2"
+"@tybys/wasm-util@npm:^0.10.3":
+  version: 0.10.3
+  resolution: "@tybys/wasm-util@npm:0.10.3"
   dependencies:
     tslib: "npm:^2.4.0"
-  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
+  checksum: 10c0/fd2bd2a79c6cd8c79ed1cf7a0fa375c64589264c88a27acaf9756d556b453ea222b62a4f68dd2fbb8b3a78b6bab3b1f4fb2431b6afc6aeda8344b53a521a1cd3
   languageName: node
   linkType: hard
 
@@ -1398,10 +1398,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"abbrev@npm:^4.0.0":
-  version: 4.0.0
-  resolution: "abbrev@npm:4.0.0"
-  checksum: 10c0/b4cc16935235e80702fc90192e349e32f8ef0ed151ef506aa78c81a7c455ec18375c4125414b99f84b2e055199d66383e787675f0bcd87da7a4dbd59f9eac1d5
+"abbrev@npm:^5.0.0":
+  version: 5.0.0
+  resolution: "abbrev@npm:5.0.0"
+  checksum: 10c0/8e88f5c798ea4562d28c5a3e9ad69e3879890bc5d695d8f2dffb8609be4c890aacc8f80ef4553fdd2c6a62d70c2ce8bc57b38074e383beb7487bdafa9ed42ea5
   languageName: node
   linkType: hard
 
@@ -2176,33 +2176,33 @@ __metadata:
   linkType: hard
 
 "node-gyp@npm:latest":
-  version: 12.4.0
-  resolution: "node-gyp@npm:12.4.0"
+  version: 13.0.2
+  resolution: "node-gyp@npm:13.0.2"
   dependencies:
     env-paths: "npm:^2.2.0"
     exponential-backoff: "npm:^3.1.1"
     graceful-fs: "npm:^4.2.6"
-    nopt: "npm:^9.0.0"
-    proc-log: "npm:^6.0.0"
+    nopt: "npm:^10.0.0"
+    proc-log: "npm:^7.0.0"
     semver: "npm:^7.3.5"
     tar: "npm:^7.5.4"
     tinyglobby: "npm:^0.2.12"
-    undici: "npm:^6.25.0"
-    which: "npm:^6.0.0"
+    undici: "npm:^8.4.1"
+    which: "npm:^7.0.0"
   bin:
     node-gyp: bin/node-gyp.js
-  checksum: 10c0/9acb7c798e124275a6f9c1f7eb64b5abd6196bb885a3945fb44ee0dccf435514e88cdfb0f228ee7ff76ef25107c1f39ff37a067bf92fd00b9aff9234db29ff9e
+  checksum: 10c0/29d33ccf47ffeeb5e7af925550b416f698a26a72eb10975c7eb5775c1d0cecacd76d164a4aa45503d3ddcece209db65c712be00423c69381a4cd14e2e6540559
   languageName: node
   linkType: hard
 
-"nopt@npm:^9.0.0":
-  version: 9.0.0
-  resolution: "nopt@npm:9.0.0"
+"nopt@npm:^10.0.0":
+  version: 10.0.1
+  resolution: "nopt@npm:10.0.1"
   dependencies:
-    abbrev: "npm:^4.0.0"
+    abbrev: "npm:^5.0.0"
   bin:
     nopt: bin/nopt.js
-  checksum: 10c0/1822eb6f9b020ef6f7a7516d7b64a8036e09666ea55ac40416c36e4b2b343122c3cff0e2f085675f53de1d2db99a2a89a60ccea1d120bcd6a5347bf6ceb4a7fd
+  checksum: 10c0/980d89257f9587f3e1f77877ddbf905d6aa3b738ec33e49a4fa1a059a0dd82eb28063982b150654a7ae9de386f2ead60e56172db7d37cf56de545f7392a2a26a
   languageName: node
   linkType: hard
 
@@ -2393,9 +2393,9 @@ __metadata:
   linkType: hard
 
 "picomatch@npm:^4.0.4":
-  version: 4.0.4
-  resolution: "picomatch@npm:4.0.4"
-  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  version: 4.0.7
+  resolution: "picomatch@npm:4.0.7"
+  checksum: 10c0/beb6ae02c43ae44e84883b90830196d9046b1726ead292adcf7f57945e0bb0d992d68563d87e03b484b6f3c9a5c6defda7523477f047d7f0e663f126cc01787f
   languageName: node
   linkType: hard
 
@@ -2410,10 +2410,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"proc-log@npm:^6.0.0":
-  version: 6.1.0
-  resolution: "proc-log@npm:6.1.0"
-  checksum: 10c0/4f178d4062733ead9d71a9b1ab24ebcecdfe2250916a5b1555f04fe2eda972a0ec76fbaa8df1ad9c02707add6749219d118a4fc46dc56bdfe4dde4b47d80bb82
+"proc-log@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "proc-log@npm:7.0.0"
+  checksum: 10c0/b89c2d862604f35fec795477b0c7e376feab3ba0d4f4d291c4e959567442697cf451ac557d0623c1cc38af45a78128b983410f397a10c5d3a67f76c33de4754b
   languageName: node
   linkType: hard
 
@@ -2656,11 +2656,11 @@ __metadata:
   linkType: hard
 
 "semver@npm:^7.3.5":
-  version: 7.8.4
-  resolution: "semver@npm:7.8.4"
+  version: 7.8.5
+  resolution: "semver@npm:7.8.5"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/81b7c296fd7927b80f67fa516b75fa1017caac8167795320de28e76ccbc6f7f01763c30ecd10d6a0d8fd089708ab0548a5aebb94b0870e99c2a2b4600a46389b
+  checksum: 10c0/b1f3127a5be8125a94f37188b361c212466c292c6910adce3ec106cff5dc211ccaedc4739c11bb70fda59d6fc1f040a9bca289f4e093451521a2372e5231fe0c
   languageName: node
   linkType: hard
 
@@ -2730,15 +2730,15 @@ __metadata:
   linkType: hard
 
 "tar@npm:^7.5.4":
-  version: 7.5.16
-  resolution: "tar@npm:7.5.16"
+  version: 7.5.22
+  resolution: "tar@npm:7.5.22"
   dependencies:
     "@isaacs/fs-minipass": "npm:^4.0.0"
     chownr: "npm:^3.0.0"
     minipass: "npm:^7.1.2"
     minizlib: "npm:^3.1.0"
     yallist: "npm:^5.0.0"
-  checksum: 10c0/4f37f3c4bd2ca2755fd736a5df1d573c1a868ec1b1e893346aeafa95ac510f9e2fd1469420bd866cc7904799e5bd4ac62b5d4f03fe27747d6e1e373b44505c5c
+  checksum: 10c0/1311f6be85a8157ac4c9147bae43e13923d2a1aae15e4aa1bd5239e4e03d2cf53cfe103dde7f35832fbb4c938b042856bc8e9a0afd29abd05e2d1608788c4fea
   languageName: node
   linkType: hard
 
@@ -2974,17 +2974,17 @@ __metadata:
   languageName: node
   linkType: hard
 
-"undici@npm:^6.25.0":
-  version: 6.26.0
-  resolution: "undici@npm:6.26.0"
-  checksum: 10c0/cf2b4caf58c33d6582970991290cc7a6486d6e738845f25dcdd16952d708ec844815c6d30362919764fcaf30f719891289341f1ada496f003ce2700310453a47
-  languageName: node
-  linkType: hard
-
 "undici@npm:^7.24.3":
   version: 7.24.5
   resolution: "undici@npm:7.24.5"
   checksum: 10c0/2a836f1f6ab078fde3eeb4cc8fd5b34eeaf52cfbdf16a9bab61b7223f43f7847bcd2125d1da7c4e3f5996c528bf9f7940015d39909bab80cfbd71b855470cf21
+  languageName: node
+  linkType: hard
+
+"undici@npm:^8.4.1":
+  version: 8.10.1
+  resolution: "undici@npm:8.10.1"
+  checksum: 10c0/90ac5636aa9d22fb710a261ef05e136df6b4bd7a0122201796bd2eb59ccab6661cdf4f635e543ca04420379eafe3f4d214031bbc7623214287988881c24dad55
   languageName: node
   linkType: hard
 
@@ -3164,14 +3164,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"which@npm:^6.0.0":
-  version: 6.0.1
-  resolution: "which@npm:6.0.1"
+"which@npm:^7.0.0":
+  version: 7.0.0
+  resolution: "which@npm:7.0.0"
   dependencies:
     isexe: "npm:^4.0.0"
   bin:
     node-which: bin/which.js
-  checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
+  checksum: 10c0/ca0b54f198f78bbc4b7c02e34bda8d335cb352e0adb4cbca1c37b1a957af3a879a82c4c27ca6525bc942f548d8b64f816ef6528360af9f3de55ffb9b979b620d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What's wrong

When a dependency blows past its SLA threshold before Dependicus ever files an issue, the calculated due date (first required version's publish date + `thresholdDays`) lands in the past. The issue was then created already overdue, e.g. `Update temporalio from 1.3.0 to at least 1.4.0 (due 2024-05-06)` filed in 2026. Fixes BIX-8427.

## What changed

- New `isDueDateInPast(dueDate, now?)` helper in `src/core/utils/versionUtils.ts`, exported from `@dependicus/core`. It compares by calendar day in UTC — the same way due dates are serialized onto issues — so a due date of today still counts as upcoming.
- Both reconcilers now run the calculated due date through a small `resolveDueDate` helper before writing it:
  - **Creating or reopening an issue** with a due date that has already passed: no due date is set. On Linear that means the due date field is left empty; on GitHub it means no `(due YYYY-MM-DD)` suffix in the title and no due date row in the body. The issue still reports how many days overdue the dependency is.
  - **Updating an existing issue**: a due date the issue already carries is preserved rather than cleared once it passes. Without this, every issue would lose its due date the day after the deadline, and Linear would stop showing it as overdue. Linear reads the existing value from the issue's due date field; GitHub reads it back from the `(due …)` suffix on the existing title, so titles and bodies stay stable and no needless updates are pushed.
  - FYI/notification-only dependencies are unaffected — they still get no due date.
- Docs: added a "Due dates" section to the Linear issues page and extended the GitHub issues one.

## Testing

New tests cover the helper plus both reconcilers (creation, update-preserves-existing, update-doesn't-add-past-date, and a still-upcoming due date that is set as before). I confirmed all five new reconciler assertions fail when the past-date check is neutered. Full suite: 921 passing, plus lint, format, and typecheck clean.

Beyond unit tests, I ran the real CLI in `--dry-run` mode against this repo's own dependency data, once against a build of `main` and once against this branch. Two dependencies are genuinely past their thresholds, and `main` files them with due dates that had already passed:

![Dry-run comparison of main and this branch](https://cursor.com/artifacts/c/art-53ff03cf-83a6-4f3b-98e1-7f7bb78717ea)

![New due-date tests and full suite passing](https://cursor.com/artifacts/c/art-74f44088-c4da-4a06-b50f-538ff6531837)

## Note on #95

This supersedes [#95](https://github.com/descriptinc/dependicus/pull/95), which took the same "drop the date if it's in the past" approach but folded it into `calculateDueDate` itself. That variant also wiped the due date off every existing issue the moment its deadline passed, since the reconcilers pass `undefined` straight through as an explicit `null` on update. This PR keeps `calculateDueDate` a pure calculation and applies the policy at the point of writing, so already-set deadlines survive.

Our dependency deadlines were flying south for the winter and never coming back; they're staying put now, and no goose gets a due date it has already waddled past. 🦆

<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [BIX-8427](https://linear.app/descript/issue/BIX-8427/dependicus-dont-create-due-dates-for-bugs-that-are-in-the-past)

<div><a href="https://cursor.com/agents/bc-3d287772-d36e-4d83-822e-381ab4f4f868?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3d287772-d36e-4d83-822e-381ab4f4f868&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

